### PR TITLE
Change name

### DIFF
--- a/atomica/core/project.py
+++ b/atomica/core/project.py
@@ -470,7 +470,7 @@ class Project(object):
         progset = self.progset(optim.progsetname)
         progset_instructions = ProgramInstructions(alloc=None, start_year=optim_ins.json['start_year'])
         optimized_instructions = optimize(self, optim, parset, progset, progset_instructions)
-        optimized_result = self.run_sim(parset=parset, progset=progset, progset_instructions=optimized_instructions,result_name=optim_ins.name)
+        optimized_result = self.run_sim(parset=parset, progset=progset, progset_instructions=optimized_instructions,result_name="Optimized")
         unoptimized_result = self.run_sim(parset=optim.parsetname, progset=optim.progsetname, progset_instructions=ProgramInstructions(start_year=optim_ins.json['start_year']), result_name="Baseline")
         results = [unoptimized_result, optimized_result]
         return results


### PR DESCRIPTION
![image](https://user-images.githubusercontent.com/755796/43447367-ef8d82c6-94dd-11e8-91ea-8fd0c9c74fa9.png)

This is a quick fix that results in all optimized simulations being called 'Optimized' - we can revisit this if users ever want to plot more than one optimization at a time (e.g. I can easily imagine cases where it would be useful later to be able to superimpose a couple of different optimizations)