### PR TITLE
Change simulation end time to match optimization end year

### DIFF
--- a/atomica/core/project.py
+++ b/atomica/core/project.py
@@ -469,9 +469,12 @@ class Project(object):
         parset = self.parset(optim.parsetname)
         progset = self.progset(optim.progsetname)
         progset_instructions = ProgramInstructions(alloc=None, start_year=optim_ins.json['start_year'])
+        original_end = self.settings.sim_end
+        self.settings.sim_end = optim_ins.json['end_year']
         optimized_instructions = optimize(self, optim, parset, progset, progset_instructions)
         optimized_result = self.run_sim(parset=parset, progset=progset, progset_instructions=optimized_instructions,result_name="Optimized")
         unoptimized_result = self.run_sim(parset=optim.parsetname, progset=optim.progsetname, progset_instructions=ProgramInstructions(start_year=optim_ins.json['start_year']), result_name="Baseline")
+        self.settings.sim_end = original_end
         results = [unoptimized_result, optimized_result]
         return results
 


### PR DESCRIPTION
This update will cause the optimization to only run for the requested time period e.g. the demo simulation ends in 2025

![image](https://user-images.githubusercontent.com/755796/43460710-05270442-9504-11e8-98d6-e93625e88be0.png)


