### PR TITLE
Fix calibration default pars and comps/characs

### DIFF
--- a/atomica/core/project.py
+++ b/atomica/core/project.py
@@ -426,10 +426,10 @@ class Project(object):
         if parset is None: parset = -1
         parset = self.parsets[parset]
         if adjustables is None:
-            adjustables = self.framework.specs[FS.KEY_PARAMETER].keys()
+            adjustables = list(self.framework.pars.index[self.framework.pars['Can Calibrate']=='y'])
         if measurables is None:
-            measurables = self.framework.specs[FS.KEY_COMPARTMENT].keys()
-            measurables += self.framework.specs[FS.KEY_CHARACTERISTIC].keys()
+            measurables = list(self.framework.comps.index)
+            measurables += list(self.framework.characs.index)
         for index, adjustable in enumerate(adjustables):
             if isinstance(adjustable, string_types):  # Assume that a parameter name was passed in if not a tuple.
                 adjustables[index] = (adjustable, None, default_min_scale, default_max_scale)


### PR DESCRIPTION
This updates `Project.calibrate` to look up variables from the Framework using the new structure, since `get_spec` is no longer used.

@cliffckerr Note that previously if no parameters were specified, then all parameters in the framework would be used for calibration, whereas now it will default to only using parameters marked as 'Can Calibrate' in the Framework (this column existed before but wasn't being used here). The old behaviour could be restored by setting `adjustables = list(self.framework.pars.index)` instead if you prefer