### PR TITLE
Fix spinner lockup

### DIFF
--- a/clients/cascade/src/components/app/CalibrationPage.vue
+++ b/clients/cascade/src/components/app/CalibrationPage.vue
@@ -190,7 +190,7 @@ Last update: 2018-07-31
     </modal>
     
     <!-- Popup spinner -->
-    <popup-spinner></popup-spinner>
+    <popup-spinner @spinner-cancel="onSpinnerCancel"></popup-spinner>
     
   </div>
 </template>
@@ -291,6 +291,10 @@ Last update: 2018-07-31
     },
 
     methods: {
+      
+      onSpinnerCancel() {
+        console.log('The user has canceled a spinner!')
+      },
 
       sleep(time) {
         // Return a promise that resolves after _time_ milliseconds.

--- a/clients/cascade/src/components/app/Spinner.vue
+++ b/clients/cascade/src/components/app/Spinner.vue
@@ -23,10 +23,6 @@
   export default {
     name: 'PopupSpinner',
     
-    created() {
-      console.log('created() run for PopupSpinner', this)
-    },
-    
     props: {
       loading: {
         type: Boolean,
@@ -102,6 +98,7 @@
       onKey(event) {
         if (event.keyCode == 27) {
           console.log('Exited spinner through Esc key')
+          this.$emit('spinner-cancel')
           this.$modal.hide('popup-spinner') // Dispel the spinner.
         }
       }


### PR DESCRIPTION
The `Spinner.vue` component has been improved in a couple of ways.  First of all, the pop-up spinners will be terminated when there is an Esc pressed, but not when a click is done.  Second, using Esc to cancel a spinner now emits a `spinner-cancel` event.  To see how this can be detected, look at the example added to the Baseline (Calibration) page.  In the future, this event (potentially modified with additional information regarding the task or RPC executed during the spinner) could be used to tell the page components that use the spinner how to cancel tasks.