### PR TITLE
Save new databook

### DIFF
--- a/atomica/core/project.py
+++ b/atomica/core/project.py
@@ -156,6 +156,7 @@ class Project(object):
             databook_path = "./databook_" + self.name + ".xlsx"
         data = ProjectData.new(self.framework, np.arange(data_start,data_end,data_dt), pops=num_pops, transfers=num_transfers)
         data.save(databook_path)
+        return data
 
     def load_databook(self, databook_path=None, make_default_parset=True, do_run=True):
         """

--- a/atomica_apps/rpcs.py
+++ b/atomica_apps/rpcs.py
@@ -775,11 +775,12 @@ def create_new_project(user_id, proj_name, num_pops, num_progs, data_start, data
     F = au.ProjectFramework(name=new_proj_name , inputs=au.atomica_path(['tests','frameworks'])+'framework_tb.xlsx')
     proj = au.Project(framework=F, name=new_proj_name) # Create the project, loading in the desired spreadsheets.
     print(">> create_new_project %s" % (proj.name))    
-    save_project_as_new(proj, user_id) # Save the new project in the DataStore.
     dirname = fileio.downloads_dir.dir_path # Use the downloads directory to put the file in.
     file_name = '%s.xlsx' % proj.name # Create a filename containing the project name followed by a .prj suffix.
     full_file_name = '%s%s%s' % (dirname, os.sep, file_name) # Generate the full file name with path.
-    proj.create_databook(databook_path=full_file_name, **args) # Return the databook
+    data = proj.create_databook(databook_path=full_file_name, **args) # Return the databook
+    proj.databook = data.to_spreadsheet()
+    save_project_as_new(proj, user_id) # Save the new project in the DataStore.
     print(">> download_databook %s" % (full_file_name))
     return full_file_name # Return the filename
 


### PR DESCRIPTION
Now when a new project is created, the user can click 'download databook' to download the original blank databook they were previously provided when creating the project.

Although the databook contains the number of populations the user specified when creating the project, to indicate that the project has not yet had data uploaded, the number of pops in the table is still printed as 'N/A' (so users should interpret this as indicating they haven't uploaded data yet)