### PR TITLE
Reject bad initializations rather than throwing error

### DIFF
--- a/atomica/core/calibration.py
+++ b/atomica/core/calibration.py
@@ -1,6 +1,7 @@
 import numpy as np
 import sciris.core as sc
 from .interpolation import interpolate_func
+from .model import BadInitialization
 
 # TODO: Determine whether this is necessary.
 calibration_settings = dict()
@@ -41,7 +42,10 @@ def calculate_objective(y_factors, pars_to_adjust, output_quantities, parset, pr
 
     update_parset(parset, y_factors, pars_to_adjust)
 
-    result = project.run_sim(parset=parset, store_results=False)
+    try:
+        result = project.run_sim(parset=parset, store_results=False)
+    except BadInitialization: # If the proposed parameters lead to invalid initial compartment sizes
+        return np.inf
 
     objective = 0.0
 

--- a/atomica/core/model.py
+++ b/atomica/core/model.py
@@ -14,6 +14,13 @@ model_settings = dict()
 model_settings['tolerance'] = 1e-6
 model_settings['iteration_limit'] = 100
 
+class BadInitialization(AtomicaException):
+    # Throw this error if the simulation exited due to a bad initialization, specifically
+    # due to negative initial popsizes or an excessive residual.
+    # This can then be dealt with appropriately - e.g. calibration will catch this
+    # error and instruct ASD to reject the proposed parameters
+    pass
+
 class Variable(object):
     """
     Lightweight abstract class to store variable array of values (presumably corresponding to an external time vector).
@@ -740,13 +747,13 @@ class Population(object):
         # Halt for an unsatisfactory overall solution (could relax this check later)
         if residual > model_settings["tolerance"]:
             print(x)
-            raise AtomicaException("Residual was {0} which is unacceptably large (should be < {1}). "
+            raise BadInitialization("Residual was {0} which is unacceptably large (should be < {1}). "
                                    "This points to a probable inconsistency in the initial "
                                    "values.".format(residual, model_settings["tolerance"]))
 
         # Halt for any negative popsizes
         if np.any(np.less(x, -model_settings['tolerance'])):
-            raise AtomicaException('Negative initial popsizes')
+            raise BadInitialization('Negative initial popsizes')
 
         # Otherwise, insert the values
         for i, c in enumerate(comps):


### PR DESCRIPTION
This PR fixes automated calibration of the HIV demo cascade.

Auto-calibration can be run on characteristics, which means it is possible for it to propose scale factors that lead to invalid initial compartment sizes. Previously this caused an error - now, this will just result in the proposed parameters being rejected, and ASD will try something else