### PR TITLE
Ensure frameworks

### DIFF
--- a/clients/cascade/src/components/app/ProjectsPage.vue
+++ b/clients/cascade/src/components/app/ProjectsPage.vue
@@ -193,7 +193,7 @@ Last update: 2018-08-08
 
       <div class="dialog-content">
         <div class="dialog-c-title">
-          Create blank project
+          Create new project
         </div>
         
         <div v-if="frameworkSummaries.length>0">     


### PR DESCRIPTION
This makes the create project GUI give a warning message if the user has no frameworks loaded.  The dialog converts to a simple message dialog with an Ok button to close it.