### PR TITLE
Cascade scenario add edit modals

### DIFF
--- a/clients/cascade/src/components/app/OptimizationsPage.vue
+++ b/clients/cascade/src/components/app/OptimizationsPage.vue
@@ -468,7 +468,7 @@ Last update: 2018-08-14
         else {
           newOptim.name = this.getUniqueName(newOptim.name, optimNames)
           this.optimSummaries.push(newOptim)
-        }       
+        }
         
         rpcservice.rpcCall('set_optim_info', [this.projectID(), this.optimSummaries])
         .then( response => {

--- a/clients/cascade/src/components/app/ScenariosPage.vue
+++ b/clients/cascade/src/components/app/ScenariosPage.vue
@@ -436,6 +436,7 @@ Last update: 2018-08-14
           // Get the index of the original (pre-edited) name
           let index = scenNames.indexOf(this.addEditModal.origName)
           if (index > -1) {
+            this.scenSummaries[index].name = newScen.name  // hack to make sure Vue table updated
             this.scenSummaries[index] = newScen
           }
           else {


### PR DESCRIPTION
The add/edit functionality has been added to the Scenarios page, in a somewhat cleaner fashion than it is implemented in the Optimizations page.  However, there is one peculiar hack I needed to add in order to get the Vue table to visibly update.  This is because when you do a bulk object copy of an object that is being watched by Vue, the update algorithm may miss the changes of the attributes inside the object.  But you can override this oversight by explicitly doing an assignment copy for the attribute you don't want Vue to miss.