### PR TITLE
Have task error display working on Optimization pages for TB and Cascade

### DIFF
--- a/clients/cascade/src/app/OptimizationsPage.vue
+++ b/clients/cascade/src/app/OptimizationsPage.vue
@@ -1,7 +1,7 @@
 <!--
 Optimizations Page
 
-Last update: 2018-09-12
+Last update: 2018-09-25
 -->
 
 <template>
@@ -416,13 +416,15 @@ Last update: 2018-09-12
         else if (optimSummary.status === 'queued')      {return 'Initializing... '} // + this.timeFormatStr(optimSummary.pendingTime)
         else if (optimSummary.status === 'started')     {return 'Running for '} // + this.timeFormatStr(optimSummary.executionTime)
         else if (optimSummary.status === 'completed')   {return 'Completed after '} // + this.timeFormatStr(optimSummary.executionTime)
+        else if (optimSummary.status === 'error')   {return 'Error after '} // + this.timeFormatStr(optimSummary.executionTime)
         else                                            {return ''}
       },
 
       timeFormatStr(optimSummary) {
         let rawValue = ''
         let is_queued = (optimSummary.status === 'queued')
-        let is_executing = ((optimSummary.status === 'started') || (optimSummary.status === 'completed'))
+        let is_executing = ((optimSummary.status === 'started') || 
+          (optimSummary.status === 'completed') || (optimSummary.status === 'error'))        
         if      (is_queued)    {rawValue = optimSummary.pendingTime}
         else if (is_executing) {rawValue = optimSummary.executionTime}
         else                   {return ''}
@@ -459,6 +461,10 @@ Last update: 2018-09-12
             optimSummary.status = statusStr
             optimSummary.pendingTime = result.data.pendingTime
             optimSummary.executionTime = result.data.executionTime
+            if (optimSummary.status == 'error') {
+              console.log('Error in task: ', optimSummary.serverDatastoreId)
+              console.log(result.data.task.errorText)
+            }            
           })
           .catch(error => {
             optimSummary.status = 'not started'
@@ -470,8 +476,9 @@ Last update: 2018-09-12
       pollAllTaskStates() {
         console.log('Polling all tasks...');
         this.optimSummaries.forEach(optimSum => { // For each of the optimization summaries...
-          console.log(optimSum.status)
-          if ((optimSum.status !== 'not started') && (optimSum.status !== 'completed')) { // If there is a valid task launched, check it.
+          console.log(optimSum.serverDatastoreId, optimSum.status)
+          if ((optimSum.status !== 'not started') && (optimSum.status !== 'completed') && 
+            (optimSum.status !== 'error')) { // If there is a valid task launched, check it.
             this.getOptimTaskState(optimSum)
           }
         });

--- a/clients/tb/src/app/OptimizationsPage.vue
+++ b/clients/tb/src/app/OptimizationsPage.vue
@@ -1,7 +1,7 @@
 <!--
 Optimizations Page
 
-Last update: 2018-09-12
+Last update: 2018-09-25
 -->
 
 <template>
@@ -416,13 +416,15 @@ Last update: 2018-09-12
         else if (optimSummary.status === 'queued')      {return 'Initializing... '} // + this.timeFormatStr(optimSummary.pendingTime)
         else if (optimSummary.status === 'started')     {return 'Running for '} // + this.timeFormatStr(optimSummary.executionTime)
         else if (optimSummary.status === 'completed')   {return 'Completed after '} // + this.timeFormatStr(optimSummary.executionTime)
+        else if (optimSummary.status === 'error')   {return 'Error after '} // + this.timeFormatStr(optimSummary.executionTime)
         else                                            {return ''}
       },
 
       timeFormatStr(optimSummary) {
         let rawValue = ''
         let is_queued = (optimSummary.status === 'queued')
-        let is_executing = ((optimSummary.status === 'started') || (optimSummary.status === 'completed'))
+        let is_executing = ((optimSummary.status === 'started') || 
+          (optimSummary.status === 'completed') || (optimSummary.status === 'error'))        
         if      (is_queued)    {rawValue = optimSummary.pendingTime}
         else if (is_executing) {rawValue = optimSummary.executionTime}
         else                   {return ''}
@@ -452,7 +454,6 @@ Last update: 2018-09-12
 
       getOptimTaskState(optimSummary) {
         console.log('getOptimTaskState() called for with: ' + optimSummary.status)
-        console.log('TEMP: ' + optimSummary.serverDatastoreId)
         let statusStr = '';
         rpcs.rpc('check_task', [optimSummary.serverDatastoreId]) // Check the status of the task.
           .then(result => {
@@ -460,6 +461,10 @@ Last update: 2018-09-12
             optimSummary.status = statusStr
             optimSummary.pendingTime = result.data.pendingTime
             optimSummary.executionTime = result.data.executionTime
+            if (optimSummary.status == 'error') {
+              console.log('Error in task: ', optimSummary.serverDatastoreId)
+              console.log(result.data.task.errorText)
+            }            
           })
           .catch(error => {
             optimSummary.status = 'not started'
@@ -471,8 +476,9 @@ Last update: 2018-09-12
       pollAllTaskStates() {
         console.log('Polling all tasks...');
         this.optimSummaries.forEach(optimSum => { // For each of the optimization summaries...
-          console.log(optimSum.status)
-          if ((optimSum.status !== 'not started') && (optimSum.status !== 'completed')) { // If there is a valid task launched, check it.
+          console.log(optimSum.serverDatastoreId, optimSum.status)
+          if ((optimSum.status !== 'not started') && (optimSum.status !== 'completed') && 
+            (optimSum.status !== 'error')) { // If there is a valid task launched, check it.
             this.getOptimTaskState(optimSum)
           }
         });


### PR DESCRIPTION
This PR improves error task processing in the Optimizations page.  Now if a Celery task ends in an error, the Status column will show "Error after [time elapsed]".  Also, the error will show up in the console, although you may have to leave the Optimizations page and scroll back to it to find it.  It remains to clean up polling so that it turns off when there are no optimizations that have task statuses of "queued" or "started".