### PR TITLE
Sum across population

### DIFF
--- a/atomica/framework.py
+++ b/atomica/framework.py
@@ -492,7 +492,8 @@ class ProjectFramework(object):
                     elif dep in self.characs.index:
                         continue
                     elif dep in self.interactions.index:
-                        if not (par['function'].startswith("SRC_POP_AVG") or par['function'].startswith("TGT_POP_AVG")):
+                        if not (par['function'].startswith("SRC_POP_AVG") or par['function'].startswith("TGT_POP_AVG")
+                                or par['function'].startswith("SRC_POP_SUM") or par['function'].startswith("TGT_POP_SUM")):
                             message = 'The function for parameter "%s" includes the Interaction "%s", which means that the parameter function can only be "SRC_POP_AVG" or "TGT_POP_AVG"' % (par.name,dep)
                             raise InvalidFramework(message)
                     elif dep in self.pars.index:

--- a/atomica/model.py
+++ b/atomica/model.py
@@ -296,9 +296,6 @@ class Parameter(Variable):
             function_args = temp_list.rstrip(")").split(',')
             function_args = [x.strip() for x in function_args]
 
-            if len(function_args) == 2: # If weighting variable not provided
-                function_args.append(None)
-
             # Convert average variable to object reference
             v1 = self.pop.get_variable(function_args[0])[0]
             if isinstance(v1, Link):

--- a/atomica/model.py
+++ b/atomica/model.py
@@ -289,7 +289,8 @@ class Parameter(Variable):
         assert sc.isstring(fcn_str), "Parameter function must be supplied as a string"
         self.fcn_str = fcn_str
         self._fcn, dep_list = parse_function(self.fcn_str)
-        if fcn_str.startswith("SRC_POP_AVG") or fcn_str.startswith("TGT_POP_AVG"):
+        if fcn_str.startswith("SRC_POP_AVG") or fcn_str.startswith("TGT_POP_AVG") or \
+                fcn_str.startswith("SRC_POP_SUM") or fcn_str.startswith("TGT_POP_SUM"):
             # The function is like 'SRC_POP_AVG(par_name,interaction_name,charac_name)'
             # self.pop_aggregation will be ['SRC_POP_AVG',parname,interaction_name,charac_object]
             special_function, temp_list = self.fcn_str.split("(")
@@ -1239,9 +1240,9 @@ class Model(object):
 
                 weights = self.interactions[pars[0].pop_aggregation[2]][:,:,ti].copy()
 
-                if pars[0].pop_aggregation[0] == 'SRC_POP_AVG':
+                if pars[0].pop_aggregation[0] in {'SRC_POP_AVG', 'SRC_POP_SUM'}:
                     weights = weights.T
-                elif pars[0].pop_aggregation[0] == 'TGT_POP_AVG':
+                elif pars[0].pop_aggregation[0] in {'TGT_POP_AVG', 'TGT_POP_SUM'}:
                     pass
                 else:
                     raise AtomicaException("Unknown aggregation function '{0}'").format(pars[0].pop_aggregation[0])  # This should never happen, an error should be raised earlier
@@ -1252,7 +1253,8 @@ class Model(object):
                     charac_vals = np.array(charac_vals).reshape(-1, 1)
                     weights *= charac_vals.T
 
-                weights /= np.sum(weights, axis=1, keepdims=1) # Normalize the interaction
+                if pars[0].pop_aggregation[0] in {'SRC_POP_AVG', 'TGT_POP_AVG'}:
+                    weights /= np.sum(weights, axis=1, keepdims=1) # Normalize the interaction
                 par_vals = np.matmul(weights, par_vals)
 
                 for par, val in zip(pars, par_vals):

--- a/atomica/parser_function.py
+++ b/atomica/parser_function.py
@@ -10,10 +10,13 @@ def to_annual(p,dt):
 # Only calls to functions in the dict below will be permitted
 supported_functions = {
     'max':max,
+    'min': min,
     'exp': np.exp,
     'floor': np.floor,
     'SRC_POP_AVG': None,
     'TGT_POP_AVG': None,
+    'SRC_POP_SUM': None,
+    'TGT_POP_SUM': None,
     'pi':np.pi,
     'cos':np.cos,
     'sin':np.sin,


### PR DESCRIPTION
I added two new functions, `TGT_POP_SUM` and `SRC_POP_SUM`, which behave just like `TGT_POP_AVG` and `SRC_POP_SUM`, respectively, without matrix normalisation. This allows to compute weighted sums across populations, which is required for malaria

Also, I added `min` to the permitted functions in the spreadsheet and fixed the bug which caused an error when `TGT_POP_AVG` or `SRC_POP_AVG` was called with only two arguments (as discussed on slack).