### PR TITLE
Replace AtomicaSpreadsheet

### DIFF
--- a/atomica/data.py
+++ b/atomica/data.py
@@ -12,7 +12,7 @@ from .utils import TimeSeries
 import sciris as sc
 from xlsxwriter.utility import xl_rowcol_to_cell as xlrc
 import openpyxl
-from .excel import cell_require_string, standard_formats, AtomicaSpreadsheet, read_tables, TimeDependentValuesEntry, TimeDependentConnections, apply_widths, update_widths, validate_category
+from .excel import cell_require_string, standard_formats, read_tables, TimeDependentValuesEntry, TimeDependentConnections, apply_widths, update_widths, validate_category
 import xlsxwriter as xw
 import io
 import numpy as np
@@ -287,9 +287,9 @@ class ProjectData(sc.prettyobj):
         self = ProjectData()
 
         if sc.isstring(spreadsheet):
-            spreadsheet = AtomicaSpreadsheet(spreadsheet)
+            spreadsheet = sc.Spreadsheet(spreadsheet)
 
-        workbook = openpyxl.load_workbook(spreadsheet.get_file(), read_only=True, data_only=True)  # Load in read-only mode for performance, since we don't parse comments etc.
+        workbook = openpyxl.load_workbook(spreadsheet.tofile(), read_only=True, data_only=True)  # Load in read-only mode for performance, since we don't parse comments etc.
         validate_category(workbook, 'atomica:databook')
 
         # These sheets are optional - if none of these are provided in the databook
@@ -459,7 +459,7 @@ class ProjectData(sc.prettyobj):
         self._book.close()
 
         # Dump the file content into a ScirisSpreadsheet
-        spreadsheet = AtomicaSpreadsheet(f)
+        spreadsheet = sc.Spreadsheet(f)
 
         # Clear everything
         f.close()

--- a/atomica/excel.py
+++ b/atomica/excel.py
@@ -83,90 +83,27 @@ def update_widths(width_dict, column_index, contents):
         width_dict[column_index] = max(width_dict[column_index], len(contents))
 
 
-class AtomicaSpreadsheet(object):
-    ''' A class for reading and writing data in binary format, so a project contains the spreadsheet loaded '''
-    # This object provides an interface for managing the contents of files (particularly spreadsheets) as Python objects
-    # that can be stored in the FE database. Basic usage is as follows:
-    #
-    # READING:
-    #
-    # ss = AtomicaSpreadsheet('input.xlsx') # Load a file into this object
-    # f = ss.get_file() # Retrieve an in-memory file-like IO stream from the data
-    # book = openpyxl.load_workbook(f) # This stream can be passed straight to openpyxl
-    #
-    # WRITING:
-    #
-    # f = io.BytesIO()
-    # book = xlsxwriter.Workbook(f)
-    # book.close()
-    # spreadsheet = AtomicaSpreadsheet(f) # note that `f.flush()` will automatically be called
-    # f.close()
-    #
-    # As shown above, no disk IO is required to manipulate the spreadsheets with openpyxl (or xlrd/xlsxwriter)
+def transfer_comments(target:sc.Spreadsheet, comment_source:sc.Spreadsheet) -> None:
+    """
+    Copy comments between spreadsheets
 
-    def __init__(self, source):
-        # Construct a new AtomicaSpreadsheet given the contents of the spreadsheet
-        #
-        # INPUTS
-        # - source : This contains the contents of the file. It can be
-        #   - A string, which is interpreted as a filename
-        #   - A file-like object like a BytesIO, the entire contents of which will be read
+    This function copies comments from one spreadsheet to another. Under the hood,
+    a new spreadsheet is created with values from the ``target`` Spreadsheet
+    and cell-wise formatting from the ``comment_source`` Spreadsheet. If a cell exists in
+    this spreadsheet and not in the source, it will be retained as-is. If more cells exist in
+    the ``comment_source`` than in this spreadsheet, those cells will be dropped. If a sheet exists in
+    the ``comment_source`` and not in the current workbook, it will be added
 
-        self.filename = None
+    :param target: The target spreadsheet to write comments into
+    :param comment_source: The source spreadsheet containing comments
 
-        if isinstance(source, io.BytesIO):
-            source.flush()
-            source.seek(0)
-            self.data = source.read()
-        else:
-            filepath = sc.makefilepath(filename=source, makedirs=False)
-            self.filename = filepath
-            self.load_date = sc.now()
-            with open(filepath, mode='rb') as f:
-                self.data = f.read()
+    """
 
-        self.load_date = sc.now()
+    assert isinstance(target, sc.Spreadsheet)
+    assert isinstance(comment_source, sc.Spreadsheet)
 
-    def __repr__(self):
-        output = sc.prepr(self)
-        return output
-
-    def save(self, filename=None):
-        # This function writes the contents of self.data to a file on disk
-        if filename is None:
-            if self.filename is not None:
-                filename = self.filename
-            else:
-                raise Exception('Cannot determine filename')
-
-        filepath = sc.makefilepath(filename=filename)
-        with open(filepath, mode='wb') as f:
-            f.write(self.data)
-        print('Spreadsheet saved to %s.' % filepath)
-
-        return filepath
-
-    def get_file(self):
-        # Return a file-like object with the contents of the file
-        # This can then be used to open the workbook from memory without writing anything to disk e.g.
-        # - book = openpyxl.load_workbook(self.get_file())
-        # - book = xlrd.open_workbook(file_contents=self.get_file().read())
-        return io.BytesIO(self.data)
-
-
-def transfer_comments(target, comment_source):
-    # Format this AtomicaSpreadsheet based on the extra meta-content in comment_source
-    #
-    # In reality, a new spreadsheet is created with values from this AtomicaSpreadsheet
-    # and cell-wise formatting from the comment_source AtomicaSpreadsheet. If a cell exists in
-    # this spreadsheet and not in the source, it will be retained as-is. If more cells exist in
-    # the comment_source than in this spreadsheet, those cells will be dropped. If a sheet exists in
-    # the comment_source and not in the current workbook, it will be added
-
-    assert isinstance(comment_source, AtomicaSpreadsheet)
-
-    this_workbook = openpyxl.load_workbook(target.get_file(), data_only=False)  # This is the value source workbook
-    old_workbook = openpyxl.load_workbook(comment_source.get_file(), data_only=False)  # A openpyxl workbook for the old content
+    this_workbook = openpyxl.load_workbook(target.tofile(), data_only=False)  # This is the value source workbook
+    old_workbook = openpyxl.load_workbook(comment_source.tofile(), data_only=False)  # A openpyxl workbook for the old content
 
     for sheet in this_workbook.worksheets:
 
@@ -180,11 +117,12 @@ def transfer_comments(target, comment_source):
                 if cell.comment:
                     sheet[cell.coordinate].comment = Comment(cell.comment.text, '')
 
+    # Save the modified spreadsheet to a new buffer
     f = io.BytesIO()
     this_workbook.save(f)
     f.flush()
     f.seek(0)
-    target.data = f.read()
+    target.load(f)
 
 
 def read_tables(worksheet):

--- a/atomica/framework.py
+++ b/atomica/framework.py
@@ -12,7 +12,7 @@ import pandas as pd
 import sciris as sc
 from .system import NotFoundError, FrameworkSettings as FS
 from .system import logger
-from .excel import read_tables, AtomicaSpreadsheet, validate_category
+from .excel import read_tables, validate_category
 from .version import version
 import numpy as np
 from .cascade import validate_cascade
@@ -29,7 +29,7 @@ class ProjectFramework(object):
     def __init__(self, inputs=None, name=None):
         # Instantiate a Framework
         # INPUTS
-        # - inputs: A string (which will load an Excel file from disk) or an AtomicaSpreadsheet
+        # - inputs: A string (which will load an Excel file from disk) or an sc.Spreadsheet
         # - A dict of sheets, which will just set the sheets attribute
         # - None, which will set the sheets to an empty dict ready for content
 
@@ -42,15 +42,15 @@ class ProjectFramework(object):
 
         # Load Framework from disk
         if sc.isstring(inputs):
-            self.spreadsheet = AtomicaSpreadsheet(inputs)
-        elif isinstance(inputs, AtomicaSpreadsheet):
+            self.spreadsheet = sc.Spreadsheet(inputs)
+        elif isinstance(inputs, sc.Spreadsheet):
             self.spreadsheet = inputs
         else:
             self.sheets = sc.odict()
             self.spreadsheet = None
             return
 
-        workbook = openpyxl.load_workbook(self.spreadsheet.get_file(), read_only=True, data_only=True)  # Load in read-write mode so that we can correctly dump the file
+        workbook = openpyxl.load_workbook(self.spreadsheet.tofile(), read_only=True, data_only=True)  # Load in read-write mode so that we can correctly dump the file
         validate_category(workbook, 'atomica:framework')
 
         self.sheets = sc.odict()

--- a/atomica/migration.py
+++ b/atomica/migration.py
@@ -12,6 +12,7 @@ can be run with more recent versions of Atomica. This module defines
 """
 
 import sys
+import io
 from distutils.version import LooseVersion
 from .system import logger
 from .version import version
@@ -27,12 +28,20 @@ import numpy as np
 # In this section, make changes to the Atomica module structure to enable pickle files
 # to be loaded at all
 
+class _Placeholder():
+    pass
+
 # First, add any placeholder modules that have been subsequently removed
 atomica.structure = types.ModuleType('structure')  # Removed 'structure' module in 1.0.12 20181107
 sys.modules['atomica.structure'] = atomica.structure
 
 # Then, remap any required classes
 atomica.structure.TimeSeries = atomica.utils.TimeSeries  # Moved 'TimeSeries' in 1.0.12 20181107
+
+# If classes have been removed, then use the Placeholder class to load them
+# The migration function can then replace Placeholder instances with actual
+# instances - see the AtomicaSpreadsheet -> sciris.Spreadsheet migration function
+atomica.excel.AtomicaSpreadsheet = _Placeholder
 
 # PROJECT MIGRATIONS
 #
@@ -310,5 +319,22 @@ def parameter_use_timeseries(proj):
             del par.t
             del par.y
             del par.autocalibrate
+
+    return proj
+
+
+@migration('1.0.14', '1.0.15', 'Replace AtomicaSpreadsheet')
+def convert_spreadsheets(proj):
+
+    def convert(placeholder):
+        new = sc.Spreadsheet(source=io.BytesIO(placeholder.data),filename=placeholder.filename)
+        new.created = placeholder.load_date
+        new.modified = placeholder.load_date
+        return new
+
+    if proj.databook is not None:
+        proj.databook = convert(proj.databook)
+    if proj.progbook is not None:
+        proj.progbook = convert(proj.progbook)
 
     return proj

--- a/atomica/programs.py
+++ b/atomica/programs.py
@@ -13,7 +13,7 @@ from .utils import NamedItem
 from numpy import array, exp, minimum, inf
 from .utils import TimeSeries
 from .system import FrameworkSettings as FS
-from .excel import standard_formats, AtomicaSpreadsheet, apply_widths, update_widths, read_tables, TimeDependentValuesEntry, validate_category
+from .excel import standard_formats, apply_widths, update_widths, read_tables, TimeDependentValuesEntry, validate_category
 from xlsxwriter.utility import xl_rowcol_to_cell as xlrc
 import openpyxl
 import xlsxwriter as xw
@@ -263,7 +263,7 @@ class ProgramSet(NamedItem):
             - A Project containing a framework and data
             - ProjectFramework and ProjectData instances without a project
 
-        :param spreadsheet: A string file path, or an AtomicaSpreadsheet
+        :param spreadsheet: A string file path, or an sc.Spreadsheet
         :param framework: A :py:class:`ProjectFramework` instance
         :param data: A :py:class:`ProjectData` instance
         :param project: A :py:class:`Project` instance
@@ -282,9 +282,9 @@ class ProgramSet(NamedItem):
 
         # Create and load spreadsheet
         if sc.isstring(spreadsheet):
-            spreadsheet = AtomicaSpreadsheet(spreadsheet)
+            spreadsheet = sc.Spreadsheet(spreadsheet)
 
-        workbook = openpyxl.load_workbook(spreadsheet.get_file(), read_only=True, data_only=True)  # Load in read-only mode for performance, since we don't parse comments etc.
+        workbook = openpyxl.load_workbook(spreadsheet.tofile(), read_only=True, data_only=True)  # Load in read-only mode for performance, since we don't parse comments etc.
         validate_category(workbook, 'atomica:progbook')
 
         # Load individual sheets
@@ -310,7 +310,7 @@ class ProgramSet(NamedItem):
         self._book.close()
 
         # Dump the file content into a ScirisSpreadsheet
-        spreadsheet = AtomicaSpreadsheet(f)
+        spreadsheet = sc.Spreadsheet(f)
 
         # Clear everything
         f.close()

--- a/atomica/project.py
+++ b/atomica/project.py
@@ -36,7 +36,6 @@ from .results import Result
 from .migration import migrate
 import sciris as sc
 import numpy as np
-from .excel import AtomicaSpreadsheet
 
 
 class ProjectSettings(object):
@@ -73,7 +72,7 @@ class Project(object):
         # INPUTS
         # - framework : a Framework to use. This could be
         #               - A filename to an Excel file on disk
-        #               - An AtomicaSpreadsheet instance
+        #               - An sc.Spreadsheet instance
         #               - A ProjectFramework instance
         #               - None (this should generally not be used though!)
         # - databook_path : The path to a databook file. The databook will be loaded into Project.data and the spreadsheet saved to Project.databook
@@ -81,7 +80,7 @@ class Project(object):
 
         self.name = name
 
-        if sc.isstring(framework) or isinstance(framework, AtomicaSpreadsheet):
+        if sc.isstring(framework) or isinstance(framework, sc.Spreadsheet):
             self.framework = ProjectFramework(inputs=framework, name=frw_name)
         elif isinstance(framework, ProjectFramework):
             self.framework = framework
@@ -104,7 +103,7 @@ class Project(object):
         self.modified = sc.now()
         self.filename = None
 
-        self.progbook = None  # This will contain an AtomicaSpreadsheet when the user loads one
+        self.progbook = None  # This will contain an sc.Spreadsheet when the user loads one
         self.settings = ProjectSettings(**kwargs)  # Global settings
 
         self._result_update_required = False  # This flag is set to True by migration is the result objects contained in this Project are out of date due to a migration change
@@ -115,10 +114,10 @@ class Project(object):
             self.load_databook(databook_path=databook_path, do_run=do_run)
         elif databook_path:
             logger.warning('Project was constructed without a Framework - databook spreadsheet is being saved to project, but data is not being loaded')
-            self.databook = AtomicaSpreadsheet(databook_path)  # Just load the spreadsheet in so that it isn't lost
+            self.databook = sc.Spreadsheet(databook_path)  # Just load the spreadsheet in so that it isn't lost
             self.data = None
         else:
-            self.databook = None  # This will contain an AtomicaSpreadsheet when the user loads one
+            self.databook = None  # This will contain an sc.Spreadsheet when the user loads one
             self.data = None
 
     def __repr__(self):
@@ -172,7 +171,7 @@ class Project(object):
         """
         Load a data spreadsheet
 
-        :param databook_path: a path string, which will load a file from disk, or an AtomicaSpreadsheet
+        :param databook_path: a path string, which will load a file from disk, or an sc.Spreadsheet
                                 containing the contents of a databook
         :param make_default_parset: If True, a Parset called "default" will be immediately created from the
                                     newly-added data
@@ -182,7 +181,7 @@ class Project(object):
 
         if sc.isstring(databook_path):
             full_path = sc.makefilepath(filename=databook_path, default=self.name, ext='xlsx', makedirs=False)
-            databook_spreadsheet = AtomicaSpreadsheet(full_path)
+            databook_spreadsheet = sc.Spreadsheet(full_path)
         else:
             databook_spreadsheet = databook_path
 
@@ -196,7 +195,7 @@ class Project(object):
 
         self.data = data
         self.data.validate(self.framework)  # Make sure the data is suitable for use in the Project (as opposed to just manipulating the databook)
-        self.databook = sc.dcp(databook_spreadsheet)  # Actually a shallow copy is fine here because AtomicaSpreadsheet contains no mutable properties
+        self.databook = sc.dcp(databook_spreadsheet)  # Actually a shallow copy is fine here because sc.Spreadsheet contains no mutable properties
         self.modified = sc.now()
         self.settings.update_time_vector(start=self.data.start_year)  # Align sim start year with data start year.
 
@@ -249,13 +248,13 @@ class Project(object):
 
         if sc.isstring(progbook_path):
             full_path = sc.makefilepath(filename=progbook_path, default=self.name, ext='xlsx', makedirs=False)
-            progbook_spreadsheet = AtomicaSpreadsheet(full_path)
+            progbook_spreadsheet = sc.Spreadsheet(full_path)
         else:
             progbook_spreadsheet = progbook_path
 
         progset = ProgramSet.from_spreadsheet(spreadsheet=progbook_spreadsheet, framework=self.framework, data=self.data, name=name)
         progset.validate()
-        self.progbook = sc.dcp(progbook_spreadsheet)  # Actually a shallow copy is fine here because AtomicaSpreadsheet contains no mutable properties
+        self.progbook = sc.dcp(progbook_spreadsheet)  # Actually a shallow copy is fine here because sc.Spreadsheet contains no mutable properties
 
         logger.debug('Updating program sets')
         self.progsets.append(progset)

--- a/atomica/version.py
+++ b/atomica/version.py
@@ -4,5 +4,5 @@ Atomica version file.
 Standard location for module version number and date.
 """
 
-version = "1.0.14"
-versiondate = "2018-11-20"
+version = "1.0.15"
+versiondate = "2018-12-17"

--- a/docs/examples/Databooks.ipynb
+++ b/docs/examples/Databooks.ipynb
@@ -282,13 +282,20 @@
     "A number of possible operations can be performed on `ProjectData`\n",
     "\n",
     "- Get a new instance using `ProjectData.new()` where you pass in a Framework together with a list (or number) or populations and transfers\n",
-    "- Use `to_spreadsheet()` to get an `AtomicaSpreadsheet` of the data, and `save()` to write the `ProjectData` to disk\n",
+    "- Use `to_spreadsheet()` to get a sciris `Spreadsheet` representation of the data, and `save()` to write the `ProjectData` to disk\n",
     "- Use `get_ts()` to get the time-data associated with a quantity out of `ProjectData` e.g. when making parameters\n",
     "- You can add or remove populations and transfers while keeping data intact\n",
     "- You can change the time values using `change_tvec()` while keeping the data intact\n",
     "\n",
     "Note that you can also change the time values in the spreadsheet in place just by adding or removing columns. In principle, you can also specify values only for a subset of populations, but at the moment this is probably not propagated through the model yet."
    ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": []
   }
  ],
  "metadata": {
@@ -307,7 +314,7 @@
    "name": "python",
    "nbconvert_exporter": "python",
    "pygments_lexer": "ipython3",
-   "version": "3.6.6"
+   "version": "3.6.5"
   },
   "toc": {
    "base_numbering": 1,

--- a/tests/test_tox_databooks.py
+++ b/tests/test_tox_databooks.py
@@ -16,9 +16,9 @@ def test_databooks():
     data = ProjectData.from_spreadsheet(at.LIBRARY_PATH + "tb_databook.xlsx",F)
     data.save(tmpdir + 'd_blug.xlsx')
 
-    # Copy comments, using lower-level AtomicaSpreadsheet (for in-memory file operations)
-    original_workbook = at.AtomicaSpreadsheet(at.LIBRARY_PATH + "tb_databook.xlsx")
-    new_workbook = data.to_spreadsheet() # This is a AtomicaSpreadsheet that can be stored in the FE database
+    # Copy comments, using lower-level Spreadsheet object (for in-memory file operations)
+    original_workbook = sc.Spreadsheet(at.LIBRARY_PATH + "tb_databook.xlsx")
+    new_workbook = data.to_spreadsheet() # This is a sc.Spreadsheet that can be stored in the FE database
     transfer_comments(new_workbook,original_workbook)
     new_workbook.save(tmpdir + 'd_blug_formatted.xlsx')
 

--- a/tests/test_tox_migration.py
+++ b/tests/test_tox_migration.py
@@ -16,5 +16,7 @@ def test_migration():
 
     at.plot_series(at.PlotData(results))
 
+    P.databook.save(tmpdir + 'migration_test_databook_save')
+
 if __name__ == '__main__':
     test_migration()


### PR DESCRIPTION
This PR deprecates `AtomicaSpreadsheet` replacing it with `sc.Spreadsheet`. The migration used here (`migration.py:convert_spreadsheets()`) also serves as a working example of how to replace one class with another during the load process