### PR TITLE
Capacity scenarios

### DIFF
--- a/atomica/defaults.py
+++ b/atomica/defaults.py
@@ -106,7 +106,7 @@ def default_project(which=None, do_run=True, addprogs=True, verbose=False, show_
     P = Project(framework=framework_file, databook_path=LIBRARY_PATH + which + "_databook.xlsx", do_run=False, **kwargs)
     P.settings.sim_dt = dtdict[which]
     if do_run:
-        P.run_sim()
+        P.run_sim(store_results=True)
     if addprogs:
         if verbose:
             print('Loading progbook')

--- a/atomica/plotting.py
+++ b/atomica/plotting.py
@@ -569,7 +569,7 @@ class PlotData():
 
         outputs = _expand_dict(outputs)
 
-        assert quantity in ['spending', 'coverage_number', 'coverage_eligible', 'coverage_fraction']
+        assert quantity in ['spending', 'coverage_number', 'coverage_eligible', 'coverage_fraction', 'coverage_capacity']
         # Make a new PlotData instance
         # We are using __new__ because this method is to be formally considered an alternate constructor and
         # thus bears responsibility for ensuring this new instance is initialized correctly
@@ -583,10 +583,14 @@ class PlotData():
                 all_vals = result.get_alloc()
                 units = '$'
                 timescales = dict.fromkeys(all_vals,1.0)
-            elif quantity == 'coverage_number':
-                all_vals = result.get_coverage('number')
+            elif quantity in {'coverage_capacity','coverage_number'}:
+                if quantity == 'coverage_capacity':
+                    all_vals = result.get_coverage('capacity')
+                else:
+                    all_vals = result.get_coverage('number')
                 units = 'Number of people'
-                # Coverage comes out as a number of people at each timestep, but we need to know
+
+                # Capacity and number coverage comes out as a number of people at each timestep, but we need to know
                 # whether that value is distributed across the year or not. A dt-coverage of 100 for a
                 # treatment program implies 400 people/year, while a dt-coverage of 100 for ART only
                 # has 100 people/year. Here, we convert the number covered at each timestep into an

--- a/atomica/plotting.py
+++ b/atomica/plotting.py
@@ -589,18 +589,7 @@ class PlotData():
                 else:
                     all_vals = result.get_coverage('number')
                 units = 'Number of people'
-
-                # Capacity and number coverage comes out as a number of people at each timestep, but we need to know
-                # whether that value is distributed across the year or not. A dt-coverage of 100 for a
-                # treatment program implies 400 people/year, while a dt-coverage of 100 for ART only
-                # has 100 people/year. Here, we convert the number covered at each timestep into an
-                # annualized coverage rate (and set the timescale accordingly). Thus, for
-                # that example, we return 400 and 100, respectively.
                 timescales = dict.fromkeys(all_vals,1.0)
-                for prog_name in all_vals:
-                    if '/year' not in result.model.progset.programs[prog_name].unit_cost.units:
-                        all_vals[prog_name] /= result.dt
-
             elif quantity == 'coverage_eligible':
                 all_vals = result.get_coverage('eligible')
                 units = 'Number of people'

--- a/atomica/programs.py
+++ b/atomica/programs.py
@@ -74,6 +74,8 @@ class ProgramInstructions(object):
                 where spending is specified in future years ramp correctly from the program start year (and not the last year
                 that data was entered for)
     :param capacity: Overwrites to capacity. This is a dict keyed by program name, containing a scalar capacity or a TimeSeries of capacity values
+                     For convenience, the capacity overwrite should be in units of 'people/year' and it will be automatically
+                     converted to a per-timestep value based on the units for the program's unit cost.
     :param coverage: Overwrites to proportion coverage. This is a dict keyed by program name, containing a scalar coverage or a TimeSeries of coverage values
 
     """
@@ -904,9 +906,15 @@ class ProgramSet(NamedItem):
         """
         Return the spending allocation for each program
 
+        This method fuses the spending data entered in the program book with
+        any overwrites that are present in the instructions. The spending values
+        returned by this method thus reflect any budget scenarios that may be
+        present.
+
         :param tvec: array of times (in years) - this is required to interpolate time-varying spending values
         :param instructions: optionally specify instructions, which can supply a spending overwrite
         :return: Dict like ``{prog_name: np.array()}`` with spending on each program (in units of '$/year' or currency equivalent)
+
         """
 
         tvec = sc.promotetoarray(tvec)
@@ -923,6 +931,11 @@ class ProgramSet(NamedItem):
     def get_capacities(self, tvec, dt, instructions=None, sample=False) -> dict:
         """
         Return timestep capacity for all programs
+
+        For convenience, this method automatically calls :meth:`ProgramSet.get_alloc()` to
+        retrieve the spending values that are used to compute capacity. Thus, this method
+        fuses the program capacity computed with the inclusion of any budget scenarios, with
+        any capacity overwrites that are present in the instructions.
 
         :param tvec: array of times (in years) - this is required to interpolate time-varying unit costs and capacity_constraint constraints
         :param dt: scalar timestep size - this is required to adjust spending on incidence-type programs
@@ -944,23 +957,26 @@ class ProgramSet(NamedItem):
                     spending = alloc[prog.name]
                 else:
                     spending = None
-                # Note that prog.get_capacity() performs the timestep conversions as required
+                # Note that prog.get_capacity() returns capacity in units of people
                 capacities[prog.name] = prog.get_capacity(tvec=tvec, dt=dt, spending=spending, sample=False)
             else:
                 capacities[prog.name] = instructions.capacity[prog.name].interpolate(tvec)
-                # Capacity overwrites are in people/year but this method needs to return
-                # the timestep capacity
+                # Capacity overwrites are input in units of people/year so convert to units of people here
                 if '/year' not in prog.unit_cost.units:
                     capacities[prog.name] *= dt
 
         return capacities
 
     def get_prop_coverage(self, tvec, capacities, num_eligible, instructions=None, sample=False) -> dict:
-        """ Return the fractional coverage of each program
+        """
+        Return fractional coverage
 
         Note that this function is primarily for internal usage (i.e. during
         model integration or reconciliation). Since the proportion covered depends
-        on the number of people eligible for the program (the coverage denominator).
+        on the number of people eligible for the program (the coverage denominator),
+        retrieving fractional coverage after running the model is best accomplished
+        via ``Result.get_coverage('fraction')`` whereas this method is called automatically
+        during integration.
 
         Evaluating the proportion coverage for a ProgramSet is not a straight division because
 
@@ -984,14 +1000,27 @@ class ProgramSet(NamedItem):
                 prop_coverage[prog.name] = prog.get_prop_covered(tvec, capacities[prog.name], num_eligible[prog.name], sample=sample)
             else:
                 prop_coverage[prog.name] = instructions.coverage[prog.name].interpolate(tvec)
+                prop_coverage[prog.name] = minimum(prop_coverage[prog.name], 1.)
         return prop_coverage
 
     def get_outcomes(self, prop_coverage=None, sample=False) -> dict:
-        """ Get a dictionary of parameter values associated with coverage levels (at a single point in time)
+        """
+        Get program outcomes given fractional coverage
+
+        Get a dictionary of parameter values associated with coverage levels (at a single point in time)
 
         Since the modality interactions in Covout.get_outcome() assume that the coverage is scalar, this function
         will also only work for scalar coverage. Therefore, the prop coverage would normally come from
-        ProgramSet.get_prop_coverage(tvec,...) where tvec was only one year
+        ProgramSet.get_prop_coverage(tvec,...) where tvec was only one year.
+
+        Note that this function is mainly aimed at internal usage. Typically, the program-provided
+        parameter values would be best accessed by examining the appropriate output in the ``Result``.
+        For example, if the programs system overwrites the screening rate ``screen`` then it would
+        normally be easiest to run a simulation and then use ``Result.get_variable(popname,'screen')``
+
+        For computational efficiency, this method returns a flat dictionary keyed by
+        parameter-population pairs that then gets inserted into the appropriate integration objects
+        by :meth:`Model.update_pars`.
 
         :param prop_coverage: dict with coverage values ``{prog_name:val}``
         :param sample: TODO implement sampling
@@ -1001,33 +1030,36 @@ class ProgramSet(NamedItem):
         return {(covout.par, covout.pop): covout.get_outcome(prop_coverage, sample=sample) for covout in self.covouts.values()}
 
 class Program(NamedItem):
-    """ Representation of a single program
+    """
+    Representation of a single program
 
-    A Program object will be instantiated for every program listed on the 'Program Targeting'
-    sheet in the program book
+    A :class:`Program` object is instantiated for every program listed on the 'Program Targeting'
+    sheet in the program book. The :class:`Program` object contains
+
+    - Collections of targeted populations and compartments from the targeting sheet in the program book
+    - The time-dependent program properties on the spending data sheet (such as total spend and unit cost)
+
+    :param name: Short name of the program
+    :param label: Full name of the program
+    :param target_pops: List of population code names for pops targeted by the program
+    :param target_comps: List of compartment code names for compartments targeted by the program
+    :param currency: The currency to use (for display purposes only) - normally this would be set to ``ProgramSet.currency`` by ``ProgramSet.add_program()``
 
     """
 
-    def __init__(self, name, label=None, target_pops=None, target_comps=None, currency='$'):
-        """
-        :param name: Short name of the program
-        :param label: Full name of the program
-        :param target_pops: List of population code names for pops targeted by the program
-        :param target_comps: List of compartment code names for compartments targeted by the program
-        :param currency: The currency to use (for display purposes only) - normally this would be set to ``ProgramSet.currency`` by ``ProgramSet.add_program()``
-        """
+    def __init__(self, name:str, label:str=None, target_pops:list=None, target_comps:list=None, currency:str='$'):
 
         NamedItem.__init__(self, name)
-        self.name = name  # Short name of program
-        self.label = name if label is None else label  # Full name of the program
-        self.target_pops = [] if target_pops is None else target_pops  # List of populations targeted by the program
-        self.target_comps = [] if target_comps is None else target_comps  # Compartments targeted by the program - used for calculating coverage denominators
-        self.baseline_spend = TimeSeries(assumption=0.0, units=currency + '/year')  # A TimeSeries with any baseline spending data - currently not exposed in progbook
-        self.spend_data = TimeSeries(units=currency + '/year')  # TimeSeries with spending data
-        self.unit_cost = TimeSeries(units=currency + '/person (one-off)')  # TimeSeries with unit cost of program
-        self.capacity_constraint = TimeSeries(units='people/year')  # TimeSeries with capacity_constraint of program - optional - if not supplied, cost function is assumed to be linear
-        self.saturation = TimeSeries(units=FS.DEFAULT_SYMBOL_INAPPLICABLE)
-        self.coverage = TimeSeries(units='people/year')  # TimeSeries with capacity_constraint of program - optional - if not supplied, cost function is assumed to be linear
+        self.name = name  #: Short name of program
+        self.label = name if label is None else label  #: Full name of the program
+        self.target_pops = [] if target_pops is None else target_pops  #: List of populations targeted by the program
+        self.target_comps = [] if target_comps is None else target_comps  #: Compartments targeted by the program - used for calculating coverage denominators
+        self.baseline_spend = TimeSeries(assumption=0.0, units=currency + '/year')  #: A TimeSeries with any baseline spending data - currently not exposed in progbook
+        self.spend_data = TimeSeries(units=currency + '/year')  #: TimeSeries with spending data
+        self.unit_cost = TimeSeries(units=currency + '/person (one-off)')  #: TimeSeries with unit cost of program
+        self.capacity_constraint = TimeSeries(units='people/year')  #: TimeSeries with capacity_constraint of program - a hard upper bound on capacity
+        self.saturation = TimeSeries(units=FS.DEFAULT_SYMBOL_INAPPLICABLE) #: TimeSeries with saturation constraint (fractional coverage asymptotic upper bound)
+        self.coverage = TimeSeries(units='people/year')  #: TimeSeries with reference coverage values (not used in any calculations)
 
     def __repr__(self):
         ''' Print out useful info'''
@@ -1039,8 +1071,16 @@ class Program(NamedItem):
         output += '\n'
         return output
 
-    def get_spend(self, year=None, total=False):
-        ''' Convenience function for getting spending data'''
+    def get_spend(self, year=None, total:bool=False):
+        """
+        Return default program spend
+
+        :param year: A scalar, list, or array of time values to retrieve spending at
+        :param total: If True, the baseline spending value will be added to the returned spending value
+        :return: An array with spending values
+
+        """
+
         if total:
             return self.spend_data.interpolate(year) + self.baseline_spend.interpolate(year)
         else:
@@ -1048,13 +1088,22 @@ class Program(NamedItem):
 
     def get_capacity(self, tvec, spending, dt, sample=False):
         """
-        Return number of people covered
+        Return timestep capacity
+
+        This method returns the number of people covered at each timestep. For one-off
+        programs, this means the annual capacity is multiplied by the timestep size.
+        Whether timestep scaling takes place or not is determined based on the units
+        of the unit cost ($/person or $/person/year where the former is used for one-off programs).
+
+        The method takes in the spending value to support overwrites in spending value by program
+        instructions (in which case, spending should be drawn from the instructions rather than
+        the program's spending data). This is handled in :meth:`ProgramSet.get_capacities`
 
         :param tvec: A vector of times
         :param spending: A vector of spending values, the same size as ``tvec``
         :param dt: The time step size
         :param sample: TODO: Implement sampling
-        :return: Array the same size as ``tvec``, with coverage in units of 'people'
+        :return: Array the same size as ``tvec``, with coverage in units of 'people' (at each timestep)
 
         """
 
@@ -1088,6 +1137,7 @@ class Program(NamedItem):
 
         :param tvec:  An array of times
         :param capacity: An array of number of people covered (e.g. the output of ``Program.get_capacity()``)
+                         This should be in units of 'people', rather than 'people/year'
         :param eligible: The number of people eligible for the program (computed from a model object or a Result)
         :param sample: TODO - implement sampling
         :return: The fractional coverage (used to compute outcomes)

--- a/atomica/results.py
+++ b/atomica/results.py
@@ -13,8 +13,7 @@ import pandas as pd
 import sciris as sc
 from .excel import standard_formats
 from .system import FrameworkSettings as FS
-from .utils import NamedItem
-from .utils import evaluate_plot_string
+from .utils import NamedItem, evaluate_plot_string, interpolate
 
 
 class Result(NamedItem):
@@ -62,14 +61,26 @@ class Result(NamedItem):
     def pop_labels(self):
         return [x.label for x in self.model.pops]
 
-    def get_alloc(self):
-        # Return a dict with time-varying funding allocation at every time point in the simulation
+    def get_alloc(self,year=None) -> dict:
+        """
+        Return spending allocation
+
+        If the result was generated using programs, this method
+        :param year: Optionally specify a scalar or list/array of years to return budget values
+                     for. Otherwise, uses all simulation times
+        :return: Dictionary keyed by program name with arrays of spending values
+
+        """
+
         if self.model.progset is None:
             return None
-        else:
-            return self.model.progset.get_alloc(self.t, self.model.program_instructions)
 
-    def get_coverage(self, quantity:str ='fraction') -> dict:
+        if year is None:
+            year = self.t
+
+        return self.model.progset.get_alloc(year, self.model.program_instructions)
+
+    def get_coverage(self, quantity:str ='fraction', year=None) -> dict:
         """
         Return program coverage
 
@@ -78,11 +89,14 @@ class Result(NamedItem):
         because the compartment sizes and thus eligible people are known.
 
         :param quantity: One of
-            - 'capacity' - The number of people that a program is funded to reach (coverage numerator)
+            - 'capacity' - The number of people that a program is funded to reach (coverage numerator) at each timestep
+                           Note that this is returned in units of people/year, not people
             - 'eligible' - The number of people eligible for the program (coverage denominator)
             - 'fraction' - ``capacity/eligible``, the fraction coverage (maximum value is 1.0)
             - 'number' - The number of people covered (``fraction*eligible``)
-        :return: Requested values in dictionary ``{prog_name:value}``
+        :param year: Optionally specify a scalar or list/array of years to return budget values
+         for. Otherwise, uses all simulation times
+        :return: Requested values in dictionary ``{prog_name:value}`` in requested years
 
         """
 
@@ -92,7 +106,7 @@ class Result(NamedItem):
         capacities = self.model.progset.get_capacities(tvec=self.t, dt=self.dt, instructions=self.model.program_instructions)
 
         if quantity == 'capacity':
-            return capacities
+            output = capacities # We return timestep capacity here for direct comparison to num_eligible
         else:
             # Get the program coverage denominator
             num_eligible = dict()  # This is the coverage denominator, number of people covered by the program
@@ -106,31 +120,65 @@ class Result(NamedItem):
             prop_coverage = self.model.progset.get_prop_coverage(tvec=self.t, capacities=capacities, num_eligible=num_eligible, instructions=self.model.program_instructions, sample=False)
 
             if quantity == 'fraction':
-                return prop_coverage
+                output = prop_coverage
             elif quantity == 'eligible':
-                return num_eligible
+                output = num_eligible
             elif quantity == 'number':
-                return {x: num_eligible[x]*prop_coverage[x] for x in prop_coverage.keys()}
+                output = {x: num_eligible[x]*prop_coverage[x] for x in prop_coverage.keys()}
             else:
                 raise Exception('Unknown coverage type requested')
 
-    # Methods to list available comps, characs, pars, and links
-    # pop_name is required because different populations could have
+        if year is not None:
+            for k in output.keys():
+                output[k] = interpolate(self.t,output[k],sc.promotetoarray(year),extrapolate=False)
+
+        return output
+
+    # Convenience methods to list available comps, characs, pars, and links
+    # The population name is required because different populations could have
     # different contents
-    def comp_names(self, pop_name):
-        # Return compartment names for a given population
+    def comp_names(self, pop_name:str) -> list:
+        """
+        Return compartment names within a population
+
+        :param pop_name: The code name of one of the populations
+        :return: List of code names of all compartments within that population
+
+        """
+
         return sorted(self.model.get_pop(pop_name).comp_lookup.keys())
 
-    def charac_names(self, pop_name):
-        # Return characteristic names for a given population
+    def charac_names(self, pop_name:str) -> list:
+        """
+        Return characteristic names within a population
+
+        :param pop_name: The code name of one of the populations
+        :return: List of code names of all characteristics within that population
+
+        """
+
         return sorted(self.model.get_pop(pop_name).charac_lookup.keys())
 
-    def par_names(self, pop_name):
-        # Return parteristic names for a given population
+    def par_names(self, pop_name:str) -> list:
+        """
+        Return parameter names within a population
+
+        :param pop_name: The code name of one of the populations
+        :return: List of code names of all parameters within that population
+
+        """
+
         return sorted(self.model.get_pop(pop_name).par_lookup.keys())
 
-    def link_names(self, pop_name):
-        # Return link names for a given population
+    def link_names(self, pop_name:str) -> list:
+        """
+        Return link names within a population
+
+        :param pop_name: The code name of one of the populations
+        :return: List of code names of all links within that population (without duplicates)
+
+        """
+
         names = set()
         pop = self.model.get_pop(pop_name)
         for link in pop.links:

--- a/docs/examples/Plot-Programs.ipynb
+++ b/docs/examples/Plot-Programs.ipynb
@@ -56,7 +56,7 @@
    "source": [
     "# Make demo project and default budget run\n",
     "P = au.demo(which='tb')\n",
-    "instructions = au.ProgramInstructions()\n",
+    "instructions = au.ProgramInstructions(2018)\n",
     "result1 = P.run_sim(P.parsets[0],P.progsets[0],progset_instructions=instructions,result_name='Default budget')\n",
     "\n",
     "# Do a simple budget scenario so that we have different spending\n",

--- a/docs/general/Programs.rst
+++ b/docs/general/Programs.rst
@@ -22,7 +22,7 @@ The capacity of a program (in some contexts, referred to as the 'coverage numera
 
 The key difference between the two is that if a program reaches 100 people per year, and the simulation timestep is 0.25 years, then the 100 people reached by the one-off program are distributed throughout the year, and in the first quarter only 25 people can be reached by the program. In contrast, the continuous program would reach 100 people in every quarter.
 
-In terms of differentiating the two types of programs, spending on programs is always provided as '$/year'. The capacity of the program is the total spend, divided by the unit cost. For one-off programs, the unit cost is provided as '$/person' and thus the capacity would be returned as 'people/year'. For continuous programs, the unit cost is provided as '$/person/year' and thus the capacity would be returned as 'people'. Of course, dividing by 1 year would give the same number of people in units of 'people/year'.
+In terms of differentiating the two types of programs, spending on programs is always provided as '$/year'. The capacity of the program is the total spend, divided by the unit cost. For one-off programs, the unit cost is provided as '$/person' and thus the capacity would be returned as 'people/year'. For continuous programs, the unit cost is provided as '$/person/year' and thus the capacity would be returned as 'people'.
 
 Fraction covered
 ^^^^^^^^^^^^^^^^

--- a/docs/general/Programs.rst
+++ b/docs/general/Programs.rst
@@ -1,0 +1,41 @@
+Programs
+========
+
+General workflow
+----------------
+
+The role of the programs system is to map spending on interventions to model parameter values. The strategy is
+
+1. Use spending and unit cost to calculate the program's capacity
+2. Use the program's capacity and the number of people eligible for the program to compute the fraction covered
+3. Use the fraction covered to calculate the parameter value
+
+We now discuss
+
+Capacity
+^^^^^^^^
+
+The capacity of a program (in some contexts, referred to as the 'coverage numerator') can be thought of as the maximum number of people that could be reached by an intervention for a given budget. For example, it might correspond to the number of doses of a treatment that can be purchased with the available funds. There are fundamentally two types of programs
+
+- One-off programs, in which a cost is incurred every time a person is reached by a program (e.g. the cost per dose of a treatment)
+- Continuous programs, in which a cost is incurred over a period of time for a person being reached by the program (e.g. the cost of providing ART to a person for a year)
+
+The key difference between the two is that if a program reaches 100 people per year, and the simulation timestep is 0.25 years, then the 100 people reached by the one-off program are distributed throughout the year, and in the first quarter only 25 people can be reached by the program. In contrast, the continuous program would reach 100 people in every quarter.
+
+In terms of differentiating the two types of programs, spending on programs is always provided as '$/year'. The capacity of the program is the total spend, divided by the unit cost. For one-off programs, the unit cost is provided as '$/person' and thus the capacity would be returned as 'people/year'. For continuous programs, the unit cost is provided as '$/person/year' and thus the capacity would be returned as 'people'. Of course, dividing by 1 year would give the same number of people in units of 'people/year'.
+
+Fraction covered
+^^^^^^^^^^^^^^^^
+
+The fraction covered is given by dividing the program's capacity by the number of people eligible for the program. For example, if a program is targeted at a set of compartments with 100 people in total, and the program's capacity is 25, then the fraction covered is 0.25. The fraction covered is capped at 1.0 (for example, if the program's capacity was greater than 100 people), and is non-dimensional.
+
+The number of people eligible for the program is given by summing the targeted compartments at a particular instant in time. Thus, in this calculation, the capacity must be in units of 'people' rather than 'people/year'. For a one-off program, the fraction covered therefore needs to be multiplied by the simulation timestep prior to performing this calculation. So for example, with a total spend of 1000 ($/year) and a unit cost of 10 ($/person) the capacity would be 100 (people/year) and with a timestep of 0.25, in the first quarter, the capacity would be 100*0.25 (people), which is the required result for a one-off program.
+
+Program outcomes
+^^^^^^^^^^^^^^^^
+
+- Additive
+- Random
+- Nested
+
+

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,6 +1,7 @@
 # Dependencies for testing/documentation
 pytest
 pytest-xdist
+pytest-env
 nbsmoke
 git+https://github.com/sciris/sciris
 git+https://github.com/sciris/mpld3

--- a/tests/test_malaria.py
+++ b/tests/test_malaria.py
@@ -15,7 +15,7 @@ P.load_databook(at.LIBRARY_PATH+'malaria_databook.xlsx', do_run=False)
 # P.make_progbook(at.LIBRARY_PATH'malaria_progbook.xlsx', progs=17)
 P.load_progbook(at.LIBRARY_PATH+'malaria_progbook.xlsx''')
 
-instructions = at.ProgramInstructions()
+instructions = at.ProgramInstructions(2018)
 
 res = P.run_sim('default', 'default', instructions)
 # P.save('malaria')

--- a/tests/test_tox_scenarios.py
+++ b/tests/test_tox_scenarios.py
@@ -1,0 +1,93 @@
+"""
+Check whether automated model documentation template generation works
+"""
+
+import os
+import atomica as at
+import sciris as sc
+
+def test_program_scenarios():
+
+    P = at.demo('tb',do_run=False)
+
+    # Get the default values for coverage etc.
+    instructions = at.ProgramInstructions(2018)
+    res_baseline = P.run_sim(result_name='Baseline',parset='default',progset='default',progset_instructions=instructions)
+
+    alloc = res_baseline.get_alloc(2018)
+    capacity = res_baseline.get_coverage('capacity',2018)
+    coverage = res_baseline.get_coverage('fraction',2018)
+
+    # # Run an allocation scenario manually
+    # doubled_budget = {x: v * 2 for x, v in alloc.items()}
+    # instructions = at.ProgramInstructions(2018,alloc=doubled_budget)
+    # res_doubled = P.run_sim(result_name='Doubled budget',parset='default',progset='default',progset_instructions=instructions)
+    #
+    # # Compare spending in 2018
+    # d = at.PlotData.programs([res_baseline, res_doubled],quantity='spending')
+    # d.interpolate(2018)
+    # at.plot_bars(d,stack_outputs='all')
+
+    # Run a capacity scenario manually
+    doubled_capacity = {x: v * 2 for x, v in capacity.items()}
+    instructions = at.ProgramInstructions(2018,capacity=doubled_capacity)
+    res_capacity = P.run_sim(result_name='Doubled capacity',parset='default',progset='default',progset_instructions=instructions)
+
+    # Compare capacity in 2018
+    d = at.PlotData.programs([res_baseline, res_capacity],quantity='coverage_capacity')
+    d.interpolate(2018)
+    at.plot_bars(d,stack_outputs='all')
+
+
+
+    scen = at.BudgetScenario(name='Doubled budget', alloc=doubled_budget, start_year=2018)
+    scen.run(proj, parset='default', progset='default')
+
+
+    alloc[0] = alloc[0]*2
+
+    # Get
+    # Low level scenarios - assigning to ProgramInstructions directly
+    alloc = proj.progsets[0].get_alloc(2018)
+    doubled_budget = {x: v * 2 for x, v in alloc.items()}
+
+
+
+    # Three different types of scenario
+    def run_budget_scenario(proj):
+        """ Run a budget scenario
+
+        :param proj: A Project object
+        :return: None
+
+        """
+
+        print('Testing budget scenario')
+
+        alloc = proj.progsets[0].get_alloc(2018)
+        doubled_budget = {x: v * 2 for x, v in alloc.items()}
+        scen = at.BudgetScenario(name='Doubled budget', alloc=doubled_budget, start_year=2018)
+        scen.run(proj, parset='default', progset='default')
+
+        return
+
+    def run_coverage_scenario(proj):
+        """ Run a coverage scenario
+
+        :param proj: A Project object
+        :return: None
+
+        """
+
+        print('Testing coverage scenario')
+
+        half_coverage = {x: 0.5 for x in proj.progsets[0].programs.keys()}
+        scen = at.CoverageScenario(name='Reduced coverage', coverage=half_coverage, start_year=2018)
+        scen.run(proj, parset='default', progset='default')
+
+        return
+
+
+if __name__ == '__main__':
+    test_program_scenarios()
+

--- a/tox.ini
+++ b/tox.ini
@@ -11,9 +11,7 @@ deps = -rrequirements.txt
 commands =
     pytest --nbsmoke-run {toxinidir} {posargs}
 
-# Enable headless testing of code that calls plotting functions
-setenv = MPLBACKEND = agg
-         PYTHONWARNINGS = ignore::DeprecationWarning
+
 
 ;[testenv:docs]
 ;description = Use sphinx-build to build the HTML docs
@@ -28,3 +26,7 @@ console_output_style = count
 testpaths = tests docs/examples
 python_files = test_tox_*.py
 norecursedirs = atomica_apps .ipynb_checkpoints
+# Enable headless matplotlib testing and suppress deprecation warnings
+env =
+    MPLBACKEND = agg
+    PYTHONWARNINGS = ignore::DeprecationWarning

--- a/tox.ini
+++ b/tox.ini
@@ -1,5 +1,5 @@
 [tox]
-envlist = py37
+envlist = py36, py37
 
 [testenv]
 description = Run basic usage tests
@@ -13,6 +13,7 @@ commands =
 
 # Enable headless testing of code that calls plotting functions
 setenv = MPLBACKEND = agg
+         PYTHONWARNINGS = ignore::DeprecationWarning
 
 ;[testenv:docs]
 ;description = Use sphinx-build to build the HTML docs


### PR DESCRIPTION
This PR 'completes' program scenarios by adding a third scenario type, 'capacity scenarios' in which program capacity is able to be overwritten. Thus program scenarios can be applied at each stage of the program calculation

- Overwrite spending
- Overwrite capacity
- Overwrite fractional coverage

Since there are not expected to be many use cases for capacity scenarios, the low-level functionality in `ProgramInstructions` has been implemented, but a corresponding `Scenario` type has not been defined, so capacity scenarios would need to be run by directly instantiating the appropriate `ProgramInstructions` object. 

Examples of all three scenarios, both as low-level scenarios and via `Scenario` objects (for budget and coverage scenarios) are provided in `test_tox_scenarios.py`