### PR TITLE
Minor fix for programs

### DIFF
--- a/atomica/programs.py
+++ b/atomica/programs.py
@@ -1012,9 +1012,9 @@ class Covout(object):
         # This is important because it also updates the modality interaction outcomes
         # These are otherwise expensive to compute
 
-        # First, sort the program dict by the magnitude of the outcome
+        # First, sort the program dict by the magnitude of the delta
         prog_tuple = [(k, v) for k, v in progs.items()]
-        prog_tuple = sorted(prog_tuple, key=lambda x: -abs(x[1]))
+        prog_tuple = sorted(prog_tuple, key=lambda x: -abs(x[1]-self.baseline))
         self.progs = sc.odict()
         for item in prog_tuple:
             self.progs[item[0]] = item[1]


### PR DESCRIPTION
The program outcomes for the additive+random interaction need to be sorted by delta rather than outcome, so that the most effective program is picked even if the effect of the program is to decrease the parameter value