### PR TITLE
Deprecate functions

### DIFF
--- a/atomica/function_parser.py
+++ b/atomica/function_parser.py
@@ -10,46 +10,6 @@ an executable Python representation.
 import ast
 import numpy as np
 
-
-def to_timestep(p: float, dt: float) -> float:
-    """ Convert from annual to timestep probability
-
-    The timestep-probability of an event is different to the annual probability.
-    This function provides a clean syntax for this transformation in the Framework
-
-    :param p: Annual probability
-    :param dt: Timestep (in years)
-    :return: Timestep probability
-
-    Example usage:
-
-    >>> to_timestep(0.9,0.25)
-    0.4376586748096509
-
-    """
-
-    return 1. - (1. - p)**dt
-
-
-def to_annual(p: float, dt: float) -> float:
-    """
-    Convert from timestep probability to annual probability
-
-    This function is the inverse of py:function:`to_timestep`. The main usage
-    case would be for implementation proportional outcomes for transition parameters
-    out of non-junction compartments. Users may enter proportions of outcomes as
-    per-timestep probabilities, and this function will convert the value to the
-    corresponding annualized probability required by the model.
-
-    :param p: Timestep probability
-    :param dt: Timestep (in years)
-    :return: Annual probability
-
-    """
-
-    return 1 - (1 - p)**(1. / dt)
-
-
 # Only calls to functions in the dict below will be permitted
 supported_functions = {
     'max': np.maximum,
@@ -65,8 +25,6 @@ supported_functions = {
     'sin': np.sin,
     'sqrt': np.sqrt,
     'ln': np.log,
-    'to_timestep': to_timestep,
-    'to_annual': to_annual,
 }
 
 

--- a/docs/general/Parameters.rst
+++ b/docs/general/Parameters.rst
@@ -13,14 +13,7 @@ Parameters are all defined on the 'Parameters' sheet of the framework. Depending
 Functions
 *********
 
-In the framework, a parameter can have a function associated with it, which can compute the value of a parameter based on the values of other integration objects like compartments, characteristics, parameters, and links (flow rates). You can also refer to the simulation time as `t` and the time step as `dt`. 
-
-Standard math operations can be performed, as well as common functions like ``max``, ``min``, ``exp`` etc. Valid functions can be found in ``function_parser.py``. In addition to the standard functions, two special functions are  
-
-- ``to_timestep(p,dt)`` that converts from annual probability to probability over a different time period 
-- ``to_annual(p,dt)`` that converts from a particular timestep probability to annual probability
-
-Together, these functions facilitate conversion from probabilities to proportions and vice versa.
+In the framework, a parameter can have a function associated with it, which can compute the value of a parameter based on the values of other integration objects like compartments, characteristics, parameters, and links (flow rates). You can also refer to the simulation time as `t` and the time step as `dt`. Standard math operations can be performed, as well as common functions like ``max``, ``min``, ``exp`` etc. Valid functions can be found in ``function_parser.py``. 
 
 Parameters are updated in the order in which they appear in the framework. This means that parameter functions can only refer to parameters that appear above them in the framework. Atomica will automatically validate this when the framework is loaded. This also means that any program overwrites that affect terms inside a parameter function will be performed prior to the function being evaluated. 
 


### PR DESCRIPTION
The `to_timestep()` and `to_annual()` functions are out of date because the method for scaling probabilities with timestep has changed as per https://docs.atomica.tools/en/master/examples/Probability-Rescaling.html. As the new method involves straight multiplication and division, it is cleaner to write them explicitly rather than using these functions, so these can be deprecated