### PR TITLE
Add in remaining features to support currencies fully

### DIFF
--- a/atomica/plotting.py
+++ b/atomica/plotting.py
@@ -724,7 +724,7 @@ class PlotData:
 
             if quantity == 'spending':
                 all_vals = result.get_alloc()
-                units = '$'
+                units = result.model.progset.currency
                 timescales = dict.fromkeys(all_vals,1.0)
             elif quantity in {'coverage_capacity','coverage_number'}:
                 if quantity == 'coverage_capacity':
@@ -751,7 +751,6 @@ class PlotData:
                         labels = output[output_name]  # These are the quantities being aggregated
 
                         # We only support summation for combining program spending, not averaging
-                        # TODO - if/when we track which currency, then should check here that all of the programs have the same currency
                         vals = sum(all_vals[x] for x in labels)
                         output_name = output_name
                         data_label = None  # No data present for aggregations
@@ -1487,7 +1486,7 @@ def plot_series(plotdata, plot_type='line', axis=None, data=None, legend_mode=No
 
                 units = list(set([plotdata[result, pop, output].unit_string for output in plotdata.outputs]))
                 if len(units) == 1 and units[0]:
-                    ax.set_ylabel(units[0].capitalize())
+                    ax.set_ylabel(units[0][0].upper() + units[0][1:])
 
                 if plotdata.pops[pop] != FS.DEFAULT_SYMBOL_INAPPLICABLE:
                     ax.set_title('%s-%s' % (plotdata.results[result], plotdata.pops[pop]))

--- a/atomica/programs.py
+++ b/atomica/programs.py
@@ -694,7 +694,16 @@ class ProgramSet(NamedItem):
                 logger.warning('Program %s: Typically if the unit cost is `/year` then the coverage would not be `/year`', prog.label)
             times.update(set(tdve.tvec))
 
-        self.tvec = array(sorted(list(times)))  # NB. This means that the ProgramSet's tvec (used when writing new programs) is based on the last Program to be read in
+        # Work out the currency
+        units = set([x.spend_data.units.split('/')[0].strip() for x in self.programs.values()])
+        units.update([x.unit_cost.units.split('/')[0].strip() for x in self.programs.values()])
+
+        if len(units) == 1:
+            self.currency = list(units)[0]
+        else:
+            raise Exception('The progbook contains multiple currencies: (%s). All spending must be specified in the same currency' % (units))
+
+        self.tvec = array(sorted(list(times)))  # NB. This means that  the ProgramSet's tvec (used when writing new programs) is based on the last Program to be read in
 
     def _write_spending(self):
         sheet = self._book.add_worksheet("Spending data")

--- a/tests/test_plot_programs.py
+++ b/tests/test_plot_programs.py
@@ -1,7 +1,7 @@
 import atomica as at
 P = at.demo(which='tb')
 
-instructions = at.ProgramInstructions()
+instructions = at.ProgramInstructions(start_year=2018)
 result1 = P.run_sim(P.parsets[0],P.progsets[0],progset_instructions=instructions,result_name='Default budget')
 #
 # # Override the default budget (these are relatively minor tweaks)
@@ -20,7 +20,7 @@ alloc = {'BCG': 350000.0,
 instructions = at.ProgramInstructions(alloc=alloc,start_year=2018)
 result2 = P.run_sim(P.parsets[0],P.progsets[0],progset_instructions=instructions,result_name='Modified budget')
 
-## SPENDING PLOTS
+# SPENDING PLOTS
 
 # Stacked time series of spending
 d = at.PlotData.programs(result1)
@@ -61,15 +61,14 @@ at.plot_bars(d,stack_outputs='all')
 
 ## COVERAGE PLOTS
 
-# Stacked time series of spending
 d = at.PlotData.programs(result1,quantity='coverage_number')
 at.plot_series(d,plot_type='stacked')
 
-d = at.PlotData.programs(result1,quantity='coverage_denominator')
+d = at.PlotData.programs(result1,quantity='coverage_eligible')
 at.plot_series(d,plot_type='stacked')
 
 d = at.PlotData.programs(result1,quantity='coverage_fraction')
 at.plot_series(d,plot_type='line')
 
-d = at.PlotData.programs(result1,t_bins='all',accumulate='integrate')
+d = at.PlotData.programs(result1,accumulate='integrate')
 at.plot_series(d,plot_type='stacked')


### PR DESCRIPTION
Currencies are currently partially supported in Atomica - `ProgramSet` objects contain currencies, but they were not being read in automatically from the progbook or plotted correctly. This PR adds in the remaining features. 

- To write a new progbook with a different currency, pass the `currency` argument to the constructor
- When a progbook is read in, the currency is set based on the spending data sheet, and validated to ensure all quantities are in the same units
- When plotting, the local currency is plotted. The axis label is formatted correctly even if the currency is a string rather than a symbol e.g. 'USD' instead of '$'