### PR TITLE
Case fixes

### DIFF
--- a/atomica/framework.py
+++ b/atomica/framework.py
@@ -898,13 +898,19 @@ class ProjectFramework(object):
             else:
                 return FS.QUANTITY_TYPE_NUMBER.title()
         elif item_type == FS.KEY_PARAMETER:
+            units = item_spec['format'].strip() if item_spec['format'] is not None else None
             if item_spec['timescale']:
-                if item_spec['format'] == FS.QUANTITY_TYPE_DURATION:
+                if units is None:
+                    raise InvalidFramework(f'A timescale was provided for Framework quantity {code_name} but no units were provided')
+                elif units.lower() == FS.QUANTITY_TYPE_DURATION:
                     return '%s (%s)' % (FS.QUANTITY_TYPE_DURATION.title(),format_duration(item_spec['timescale'],pluralize=True))
-                elif item_spec['format'] in {FS.QUANTITY_TYPE_NUMBER,FS.QUANTITY_TYPE_PROBABILITY}:
-                    return '%s (per %s)' % (item_spec['format'].title(),format_duration(item_spec['timescale'],pluralize=False))
-            elif item_spec['format']:
-                return item_spec['format']
+                elif units.lower() in {FS.QUANTITY_TYPE_NUMBER,FS.QUANTITY_TYPE_PROBABILITY}:
+                    return '%s (per %s)' % (units.title(),format_duration(item_spec['timescale'],pluralize=False))
+                else:
+                    if units is None:
+                        raise InvalidFramework(f'A timescale was provided for Framework quantity {code_name} but the units were not one of duration, number, or probability. It is therefore not possible to perform any automatic conversions, simply enter the relevant data entry timescale in the units directly instead.')
+            elif units:
+                return units
 
         return FS.DEFAULT_SYMBOL_INAPPLICABLE
 

--- a/atomica/model.py
+++ b/atomica/model.py
@@ -759,7 +759,10 @@ class Population(object):
 
     def get_comp(self, comp_name):
         """ Allow compartments to be retrieved by name rather than index. Returns a Compartment. """
-        return self.comp_lookup[comp_name]
+        try:
+            return self.comp_lookup[comp_name]
+        except KeyError:
+            raise NotFoundError(f'Compartment {comp_name} not found')
 
     def get_links(self, name) -> list:
         """ Retrieve Links. """
@@ -775,11 +778,17 @@ class Population(object):
 
     def get_charac(self, charac_name):
         """ Allow dependencies to be retrieved by name rather than index. Returns a Variable. """
-        return self.charac_lookup[charac_name]
+        try:
+            return self.charac_lookup[charac_name]
+        except KeyError:
+            raise NotFoundError(f'Characteristic {charac_name} not found')
 
     def get_par(self, par_name):
         """ Allow dependencies to be retrieved by name rather than index. Returns a Variable. """
-        return self.par_lookup[par_name]
+        try:
+            return self.par_lookup[par_name]
+        except KeyError:
+            raise NotFoundError(f'Parameter {par_name} not found')
 
     def gen_cascade(self, framework, progset):
         """

--- a/atomica/parameters.py
+++ b/atomica/parameters.py
@@ -129,7 +129,7 @@ class ParameterSet(NamedItem):
         for name, tdve in data.tdve.items():
             for pop_name, ts in tdve.ts.items(): # The TDVE has already been validated to contain any required populations (although it might also contain extra ones)
                 units = framework.get_databook_units(name)
-                if units != ts.units:
+                if units.strip().lower() != ts.units.strip().lower():
                     raise Exception('The units entered in the databook do not match the units entered in the framework')
             self.pars[name] = Parameter(name,sc.dcp(tdve.ts))
 

--- a/atomica/results.py
+++ b/atomica/results.py
@@ -1278,7 +1278,14 @@ class Ensemble(NamedItem):
 
 
         locations = offset + np.arange(len(x))
-        plt.boxplot(np.vstack(x).T, positions=locations, manage_xticks=False)
+
+        # TODO - force matplotlib>=3.1 to address this
+        import matplotlib
+        if sc.compareversions(matplotlib.__version__,'3.1') < 0:
+            plt.boxplot(np.vstack(x).T, positions=locations, manage_xticks=False)
+        else:
+            plt.boxplot(np.vstack(x).T, positions=locations, manage_ticks=False)
+
         ax.set_xlim(-0.5, locations[-1] + 0.5)
         if offset == 0:
             ax.set_xticks(np.arange(locations[-1] + 1))

--- a/atomica/version.py
+++ b/atomica/version.py
@@ -6,7 +6,7 @@ Standard location for module version number and date.
 
 import sciris as sc
 
-version = "1.4.1"
+version = "1.4.2"
 versiondate = "2019-05-03"
 gitinfo = sc.gitinfo(__file__, verbose=False)
 

--- a/docs/examples/Uncertainty.ipynb
+++ b/docs/examples/Uncertainty.ipynb
@@ -1023,9 +1023,9 @@
  ],
  "metadata": {
   "kernelspec": {
-   "display_name": "Python [conda env:optima37]",
+   "display_name": "Python [conda env:atomica37]",
    "language": "python",
-   "name": "conda-env-optima37-py"
+   "name": "conda-env-atomica37-py"
   },
   "language_info": {
    "codemirror_mode": {
@@ -1037,7 +1037,7 @@
    "name": "python",
    "nbconvert_exporter": "python",
    "pygments_lexer": "ipython3",
-   "version": "3.7.0"
+   "version": "3.7.2"
   },
   "toc": {
    "base_numbering": 1,

--- a/setup.py
+++ b/setup.py
@@ -40,7 +40,7 @@ setup(
     packages=find_packages(),
     include_package_data=True,
     install_requires=[
-        'matplotlib>=1.4.2',
+        'matplotlib>=3.0',
         'numpy>=1.10.1',
         'scipy',
         'pandas',

--- a/tox.ini
+++ b/tox.ini
@@ -12,7 +12,7 @@ commands =
     pytest --nbsmoke-run {toxinidir} {posargs}
 
 [pytest]
-addopts = -ra -v -n 2 --junitxml=junit/test-results.xml
+addopts = -ra -v -n 2 --junitxml=junit/test-results.xml --color=no
 nbsmoke_cell_timeout = 600
 console_output_style = count
 testpaths = tests docs/examples


### PR DESCRIPTION
This PR improves robustness of unit validation between the framework and databook. Specifically, it is now less case and whitespace sensitive, so units like 'number' and 'Number' and 'number ' will all get treated the same for timescale formatting and validation purposes