### PR TITLE
Parscen functions

### DIFF
--- a/atomica/migration.py
+++ b/atomica/migration.py
@@ -529,5 +529,14 @@ def add_derivatives(proj):
 @migration('1.4.3', '1.5.0', 'Parameters with functions can be overwritten')
 def add_parset_disable_function(proj):
 
+    # Add skip_function flag to parset Parameter instances
+    for parset in proj.parsets.values():
+        for par in parset.all_pars():
+            par.skip_function = sc.odict.fromkeys(par.ts, None)
+
+    for result in all_results(proj):
+        for pop in result.model.pops:
+            for par in pop.pars:
+                par.skip_function = None
     return proj
 

--- a/atomica/migration.py
+++ b/atomica/migration.py
@@ -526,3 +526,8 @@ def add_derivatives(proj):
                 par.derivative = False
     return proj
 
+@migration('1.4.3', '1.5.0', 'Parameters with functions can be overwritten')
+def add_parset_disable_function(proj):
+
+    return proj
+

--- a/atomica/model.py
+++ b/atomica/model.py
@@ -368,6 +368,7 @@ class Parameter(Variable):
         self._precompute = False #: If True, the parameter function will be computed in a vector operation prior to integration
         self._is_dynamic = False #: If True, this parameter will be updated during integration. Note that `precompute` and `dynamic` are mutually exclusive
         self.derivative = False #: If True, the parameter function will be treated as a derivative and the value added on to the end
+        self.skip_function = None #: Can optionally be set to a (start,stop) tuple of times. Between these times, the parameter will not be updated so the parset value will be left unchanged
 
         #: For transition parameters, the ``vals`` stored by the parameter is effectively a rate. The ``timescale``
         #: attribute informs the time period corresponding to the units in which the rate has been provided.
@@ -528,11 +529,23 @@ class Parameter(Variable):
 
         if ti is None:
             if self.derivative:
-                raise Exception('Cannot perform a vector update of a derivate parameter')
+                raise Exception('Cannot perform a vector update of a derivative parameter (these parameters intrinsically require integration to be computed)')
             ti = np.arange(0, self.vals.size)  # This corresponds to every time point
 
         if self.derivative and ti == 0:
             return
+
+        if self.skip_function:
+            # If we don't want to overwrite the parameter in certain years, those years need to be excluded
+            if hasattr(ti, '__len__'):
+                # Filter out years outside the excluded range
+                ti = ti[np.where((self.t[ti] < self.skip_function[0]) | (self.t[ti] > self.skip_function[1]))]
+                if ti.size == 0: # If all times were removed
+                    return
+            else:
+                # Dealing with a scalar ti
+                if self.t[ti] >= self.skip_function[0] | self.t[ti] <= self.skip_function[1]:
+                    return
 
         dep_vals = dict.fromkeys(self.deps, 0.0)
         for dep_name, deps in self.deps.items():
@@ -1193,20 +1206,28 @@ class Model(object):
                         var.set_dynamic(progset=self.progset)
 
         # Insert parameter initial values and do any required precomputation
-        for par_name in self.framework.pars.index:
+        for par_name in self.framework.pars.index: # Iterate only over framework pars (parset.pars also includes characteristics)
             cascade_par = parset.pars[par_name]
             if cascade_par.name in self._vars_by_pop: # The parameter could be missing if it is defined in a population type that is not present in the simulation
                 pars = self._vars_by_pop[cascade_par.name]
                 for par in pars:
                     par.scale_factor = cascade_par.meta_y_factor # Set meta scale factor regardless of whether a population-specific y-factor is also provided
+
                     if par.pop.name in cascade_par.y_factor:
                         par.scale_factor *= cascade_par.y_factor[par.pop.name] # Add in population-specific scale factor
+
+                    if par.pop.name in cascade_par.skip_function:
+                        par.skip_function = cascade_par.skip_function[par.pop.name] # Copy in any skipped evaluations
+                        if par.skip_function:
+                            assert cascade_par.has_values(par.pop.name), 'Parameter function was marked as being skipped for some of the simulation, but the ParameterSet has no values to use instead. If skipping, the ParameterSet must contain some values'
+
                     if cascade_par.has_values(par.pop.name): # If the databook contains values, then insert them now
                         par.vals = cascade_par.interpolate(tvec=self.t, pop_name=par.pop.name) * par.scale_factor
-                        par.constrain()  # Sampling might result in the parameter value going out of bounds (or user might have entered bad values in the databook) so ensure they are clipped here
+
                     if par.fcn_str and par._precompute: # If the parameter is marked for precomputation, then insert it now
                         par.update()
-                        par.constrain()
+
+                    par.constrain()  # Sampling might result in the parameter value going out of bounds (or user might have entered bad values in the databook) so ensure they are clipped here
 
     def process(self):
         """ Run the full model. """

--- a/atomica/model.py
+++ b/atomica/model.py
@@ -544,7 +544,7 @@ class Parameter(Variable):
                     return
             else:
                 # Dealing with a scalar ti
-                if self.t[ti] >= self.skip_function[0] | self.t[ti] <= self.skip_function[1]:
+                if (self.t[ti] >= self.skip_function[0]) and (self.t[ti] <= self.skip_function[1]):
                     return
 
         dep_vals = dict.fromkeys(self.deps, 0.0)

--- a/atomica/model.py
+++ b/atomica/model.py
@@ -1198,7 +1198,7 @@ class Model(object):
             if cascade_par.name in self._vars_by_pop: # The parameter could be missing if it is defined in a population type that is not present in the simulation
                 pars = self._vars_by_pop[cascade_par.name]
                 for par in pars:
-                    par.scale_vactor = cascade_par.meta_y_factor # Set meta scale factor regardless of whether a population-specific y-factor is also provided
+                    par.scale_factor = cascade_par.meta_y_factor # Set meta scale factor regardless of whether a population-specific y-factor is also provided
                     if par.pop.name in cascade_par.y_factor:
                         par.scale_factor *= cascade_par.y_factor[par.pop.name] # Add in population-specific scale factor
                     if cascade_par.has_values(par.pop.name): # If the databook contains values, then insert them now

--- a/atomica/parameters.py
+++ b/atomica/parameters.py
@@ -28,7 +28,7 @@ class Parameter(NamedItem):
         self.ts = ts #: Population-specific data is stored in TimeSeries within this dict, keyed by population name
         self.y_factor = sc.odict.fromkeys(self.ts,1.0) #: Calibration scale factors for the parameter in each population
         self.meta_y_factor = 1.0 #: Calibration scale factor for all populations
-
+        self.skip_function = sc.odict.fromkeys(self.ts,None) #: This can be a range of years [start,stop] between which the parameter function will not be evaluated
 
     @property
     def pops(self):

--- a/atomica/scenarios.py
+++ b/atomica/scenarios.py
@@ -284,7 +284,7 @@ class ParameterScenario(Scenario):
                     raise Exception('Number of time points in overwrite does not match number of values')
 
                 if len(overwrite['t']) == 1:
-                    logger.warning('Only one time point was specified in the overwrite, which means that the overwrite will not have any effect')
+                    raise Exception('Only one time point was specified in the overwrite, which means that the overwrite will not have any effect')
 
                 for i in range(0, len(overwrite['t'])):
 

--- a/atomica/scenarios.py
+++ b/atomica/scenarios.py
@@ -112,7 +112,7 @@ class Scenario(NamedItem):
             parset = project.parset(parset)
 
         if progset is None and self.progsetname is not None:
-            progset = project.progsets[self.parsetname]
+            progset = project.progsets[self.progsetname]
         elif progset is not None:
             progset = project.progset(progset)
 

--- a/atomica/scenarios.py
+++ b/atomica/scenarios.py
@@ -264,9 +264,6 @@ class ParameterScenario(Scenario):
                 overwrite['t'] = overwrite['t'][idx]
                 overwrite['y'] = overwrite['y'][idx]
 
-                if not par.has_values(pop_label):
-                    raise Exception("You cannot specify overwrites for a parameter with a function, instead you should overwrite its dependencies")
-
                 original_y_end = par.interpolate(np.array([max(overwrite['t']) + 1e-5]), pop_label)
 
                 # If the Parameter had an assumption, then insert the assumption value in the start year
@@ -317,6 +314,9 @@ class ParameterScenario(Scenario):
 
                 # Add an extra point to return the parset back to it's original value after the final overwrite
                 par.ts[pop_label].insert(max(overwrite['t']) + 1e-5, original_y_end)
+
+                if project.framework.pars.at[par.name, 'function']:
+                    par.skip_function[pop_label] = (min(overwrite['t']), max(overwrite['t']))
 
         return new_parset
 

--- a/atomica/version.py
+++ b/atomica/version.py
@@ -6,7 +6,7 @@ Standard location for module version number and date.
 
 import sciris as sc
 
-version = "1.4.3"
-versiondate = "2019-05-03"
+version = "1.5.0"
+versiondate = "2019-05-06"
 gitinfo = sc.gitinfo(__file__, verbose=False)
 

--- a/azure-pipelines.yml
+++ b/azure-pipelines.yml
@@ -28,8 +28,14 @@ jobs:
   - task: PublishTestResults@2
     inputs:
       testResultsFiles: '**/test-*.xml'
-      testRunTitle: 'Python $(python.version)'
+      testRunTitle: 'Publish test results for Python $(python.version)'
     condition: succeededOrFailed()
+
+  - task: PublishCodeCoverageResults@1
+    inputs:
+      codeCoverageTool: Cobertura
+      summaryFileLocation: '$(System.DefaultWorkingDirectory)/**/coverage.xml'
+      reportDirectory: '$(System.DefaultWorkingDirectory)/**/htmlcov'
 
 # TODO - Switch deployment over to Azure DevOps
 

--- a/requirements.txt
+++ b/requirements.txt
@@ -2,6 +2,7 @@
 pytest
 pytest-xdist
 pytest-env
+pytest-cov
 nbsmoke
 git+https://github.com/sciris/mpld3
 nbsphinx

--- a/tests/test_tox_calibration.py
+++ b/tests/test_tox_calibration.py
@@ -1,0 +1,27 @@
+## This script checks that parameter scale factors work correctly
+
+import numpy as np
+import atomica as at
+import matplotlib.pyplot as plt
+import os
+
+def test_scale_factors():
+    P = at.demo('sir',do_run=False)
+
+    res = P.run_sim('default')
+    baseline = res.get_variable('infdeath')[0].vals[0]
+
+    ps2 = P.make_parset('scaled')
+    ps2.pars['infdeath'].y_factor['adults'] = 1.5
+    res = P.run_sim(ps2)
+    scale1 = res.get_variable('infdeath')[0].vals[0]
+
+    ps2.pars['infdeath'].meta_y_factor = 2.0
+    res = P.run_sim(ps2)
+    scale2 = res.get_variable('infdeath')[0].vals[0]
+
+    assert np.isclose(scale1, baseline*1.5, 1e-4)
+    assert np.isclose(scale2, baseline*3, 1e-4)
+
+if __name__ == '__main__':
+    test_scale_factors()

--- a/tests/test_tox_library.py
+++ b/tests/test_tox_library.py
@@ -6,6 +6,9 @@ import atomica as at
 import os
 import pytest
 import numpy as np
+import sciris as sc
+
+tmpdir = at.atomica_path(['tests', 'temp'])
 
 # List available models based on which framework files exist
 models = list()
@@ -127,6 +130,22 @@ def run_optimization(proj):
 
     return
 
+def run_export(result,model):
+    """
+    Test exporting a results
+
+    :param result:
+    :param model:
+    :return:
+    """
+
+    at.export_results(result,tmpdir+model+'_single_export_test') # Export single
+    result.export_raw(tmpdir+model+'_raw_export_test')
+    r2 = sc.dcp(result)
+    r2.name = 'Copied'
+    at.export_results([result, r2],tmpdir+model+'_multiple_export_test') # Export single
+
+
 # Testing optimizations and calibrations could be expensive
 # Using the parametrize decorator means Pytest will treat
 # each function call as a separate test, which can be run in parallel
@@ -164,7 +183,9 @@ def test_model(model):
 
     # Test loading the progbook and doing a basic run
     P.load_progbook(progbook_file)
-    P.run_sim(P.parsets[0],P.progsets[0],at.ProgramInstructions(start_year=2018))
+    res = P.run_sim(P.parsets[0],P.progsets[0],at.ProgramInstructions(start_year=2018))
+
+    run_export(res,model)
 
     # Test a reconciliation
     run_reconciliation(P)

--- a/tests/test_tox_scenarios.py
+++ b/tests/test_tox_scenarios.py
@@ -206,10 +206,29 @@ def test_parameter_scenarios():
     assert np.allclose(var2.vals[var2.t == 2015][0], 0.008, equal_nan=True)  # Default tolerances are rtol=1e-05, atol=1e-08
     assert np.allclose(var2.vals[var2.t == 2020][0], 0.005, equal_nan=True)  # Default tolerances are rtol=1e-05, atol=1e-08
 
+def test_overwrite_function_scenario():
+    proj = at.demo('sir',do_run=False)
+    proj.settings.update_time_vector(start=2000,end=2023)
+    baseline = proj.run_sim()
+
+    baseline.get_variable('foi')[0].plot()
+
+    # Check that it runs with a single overwrite
+    scen_par1 = "foi"
+    scen_pop = "adults"
+    scvalues = dict()
+    scvalues[scen_par1] = dict()
+    scvalues[scen_par1][scen_pop] = dict()
+    scvalues[scen_par1][scen_pop]["y"] = [0.1, 0.15]
+    scvalues[scen_par1][scen_pop]["t"] = [2015., 2018.]
+    scen = proj.make_scenario(which='parameter', scenario_values=scvalues)
+    scen_results = scen.run(proj, proj.parsets["default"])
+    scen_results.get_variable('foi')[0].plot()
+
 
 if __name__ == '__main__':
-    test_program_scenarios()
-    test_timevarying_progscen()
-    test_parameter_scenarios()
-    test_combined_scenario()
-
+    # test_program_scenarios()
+    # test_timevarying_progscen()
+    # test_parameter_scenarios()
+    # test_combined_scenario()
+    test_overwrite_function_scenario()

--- a/tests/test_tox_scenarios.py
+++ b/tests/test_tox_scenarios.py
@@ -225,6 +225,12 @@ def test_overwrite_function_scenario():
     scen_results = scen.run(proj, proj.parsets["default"])
     scen_results.get_variable('foi')[0].plot()
 
+    var1 = baseline.get_variable(scen_par1,scen_pop)[0]
+    var2 = scen_results.get_variable(scen_par1,scen_pop)[0]
+
+    assert np.allclose(var1.vals[var1.t == 2010][0], var2.vals[var2.t == 2010][0], equal_nan=True)  # Default tolerances are rtol=1e-05, atol=1e-08
+    assert np.allclose(var2.vals[var2.t == 2015][0], 0.1, equal_nan=True)  # Default tolerances are rtol=1e-05, atol=1e-08
+    assert np.allclose(var2.vals[var2.t == 2018][0], 0.15, equal_nan=True)  # Default tolerances are rtol=1e-05, atol=1e-08
 
 if __name__ == '__main__':
     # test_program_scenarios()

--- a/tox.ini
+++ b/tox.ini
@@ -12,7 +12,7 @@ commands =
     pytest --nbsmoke-run {toxinidir} {posargs}
 
 [pytest]
-addopts = -ra -v -n 2 --junitxml=junit/test-results.xml --color=no
+addopts = -ra -v -n 2 --junitxml=junit/test-results.xml --color=no --cov=atomica --cov-report=xml --cov-report=html
 nbsmoke_cell_timeout = 600
 console_output_style = count
 testpaths = tests docs/examples


### PR DESCRIPTION
This PR lifts the restriction that function parameters cannot be targeted. Originally this was prevented to stop users from violating the parameter functions accidentally - for example, overwriting force of infection rather than overwriting the components that get used to calculate the force of infection.

However, some frameworks use parameters functions to automate conversions from number to probability. The intended usage is for users to complete databooks in number format (e.g. number of diagnoses) but to be able to write program outcomes in probabilities (e.g. probability of diagnosis). Canonically, the databook should be in probability format and users should perform any necessary conversions beforehand - but for some models it's not realistic to expect this of users. Similarly, it should be possible to overwrite the computed probability of diagnosis e.g. if calibrating to a historical number of diagnoses but wanting to perform a parameter scenario with a fixed probability going forward.

This PR adds support for parameter functions to be turned off if the parameter has both a function and values in the `ParameterSet`. The `ParameterSet` defines when the parameter should be turned off and the `ParameterScenario` constructor sets this flag when it encounters a parameter scenario where a parameter with a function is overwritten. No change should occur for existing scenarios.

Smooth onsets cannot be computed where the previous value depends on a parameter function, so overwrites with smooth onset targeting function parameters will raise an error. 