### PR TITLE
Fix parscen inf

### DIFF
--- a/atomica/plotting.py
+++ b/atomica/plotting.py
@@ -491,7 +491,7 @@ class PlotData:
             else:
                 scale = 1.0
 
-            f = scipy.interpolate.PchipInterpolator(s.tvec/scale, s.vals, axis=0, extrapolate=False)
+            f = scipy.interpolate.interp1d(s.tvec/scale, s.vals, axis=0, kind='linear',copy=False, assume_sorted=True,bounds_error=False,fill_value=np.nan)
             vals = np.array([scipy.integrate.quadrature(f, l, u,maxiter=5*s.vals.size)[0] for l, u in zip(lower/scale, upper/scale)])
 
             if method == 'integrate':
@@ -1006,7 +1006,7 @@ class Series:
 
         """
 
-        f = scipy.interpolate.PchipInterpolator(self.tvec, self.vals, axis=0, extrapolate=False)
+        f = scipy.interpolate.interp1d(self.tvec, self.vals, axis=0, kind='linear', copy=False, assume_sorted=True, bounds_error=False, fill_value=np.nan)
         out_of_bounds = (new_tvec < self.tvec[0]) | (new_tvec > self.tvec[-1])
         if np.any(out_of_bounds):
             logger.warning('Series has values from %.2f to %.2f so requested time points %s are out of bounds', self.tvec[0], self.tvec[-1], new_tvec[out_of_bounds])

--- a/atomica/scenarios.py
+++ b/atomica/scenarios.py
@@ -326,6 +326,8 @@ class ParameterScenario(Scenario):
                 # Add an extra point to return the parset back to it's original value after the final overwrite
                 if overwrite['end_overwrite']:
                     par.ts[pop_label].insert(max(overwrite['t']) + 1e-5, original_y_end)
+                else:
+                    par.ts[pop_label].remove_after(max(overwrite['t']))
 
                 if has_function:
                     par.skip_function[pop_label] = (min(overwrite['t']), max(overwrite['t']))

--- a/atomica/scenarios.py
+++ b/atomica/scenarios.py
@@ -294,8 +294,8 @@ class ParameterScenario(Scenario):
                 if len(overwrite['t']) != len(overwrite['y']):
                     raise Exception('Number of time points in overwrite does not match number of values')
 
-                if len(overwrite['t']) == 1:
-                    raise Exception('Only one time point was specified in the overwrite, which means that the overwrite will not have any effect')
+                if len(overwrite['t']) == 1 and overwrite['end_overwrite']:
+                    raise Exception('Only one time point was specified in the overwrite and end overwrite is set to true, which means that the overwrite will not have any effect')
 
                 for i in range(0, len(overwrite['t'])):
 
@@ -323,7 +323,7 @@ class ParameterScenario(Scenario):
                     # Insert the overwrite value - assume scenario value is AFTER y-factor rescaling
                     par.ts[pop_label].insert(overwrite['t'][i], overwrite['y'][i] / par.y_factor[pop_label] / par.meta_y_factor)
 
-                # Add an extra point to return the parset back to it's original value after the final overwrite
+                # Add an extra point to return the parset back to its original value after the final overwrite
                 if overwrite['end_overwrite']:
                     par.ts[pop_label].insert(max(overwrite['t']) + 1e-5, original_y_end)
                 else:

--- a/atomica/scenarios.py
+++ b/atomica/scenarios.py
@@ -326,11 +326,12 @@ class ParameterScenario(Scenario):
                 # Add an extra point to return the parset back to its original value after the final overwrite
                 if overwrite['end_overwrite']:
                     par.ts[pop_label].insert(max(overwrite['t']) + 1e-5, original_y_end)
+                    if has_function:
+                        par.skip_function[pop_label] = (min(overwrite['t']), max(overwrite['t']))
                 else:
                     par.ts[pop_label].remove_after(max(overwrite['t']))
-
-                if has_function:
-                    par.skip_function[pop_label] = (min(overwrite['t']), max(overwrite['t']))
+                    if has_function:
+                        par.skip_function[pop_label] = (min(overwrite['t']), np.inf)
 
         return new_parset
 

--- a/atomica/utils.py
+++ b/atomica/utils.py
@@ -599,16 +599,11 @@ def interpolate(x: np.array, y: np.array, x2: np.array, extrapolate=True) -> np.
     elif x.size == 1:
         return np.full(x2.shape, y[0])
     else:
-        f = scipy.interpolate.PchipInterpolator(x, y, axis=0, extrapolate=False)
         if extrapolate:
-            y2 = np.zeros(x2.shape)
-            y2[(x2 >= x[0]) & (x2 <= x[-1])] = f(x2[(x2 >= x[0]) & (x2 <= x[-1])])
-            y2[x2 < x[0]] = y[0]
-            y2[x2 > x[-1]] = y[-1]
+            f = scipy.interpolate.interp1d(x, y, kind='linear',copy=False, assume_sorted=True,bounds_error=False,fill_value=(y[0],y[-1]))
         else:
-            y2 = f(x2)  # PchipInterpolator will return NaNs outside the domain
-        return y2
-
+            f = scipy.interpolate.interp1d(x, y, kind='linear',copy=False, assume_sorted=True,bounds_error=False,fill_value=np.nan)
+        return f(x2)
 
 def floor_interpolator(x, y):
     """

--- a/atomica/version.py
+++ b/atomica/version.py
@@ -6,7 +6,7 @@ Standard location for module version number and date.
 
 import sciris as sc
 
-version = "1.5.0"
+version = "1.5.1"
 versiondate = "2019-05-06"
 gitinfo = sc.gitinfo(__file__, verbose=False)
 

--- a/docs/examples/Plot-Programs.ipynb
+++ b/docs/examples/Plot-Programs.ipynb
@@ -449,9 +449,9 @@
  ],
  "metadata": {
   "kernelspec": {
-   "display_name": "Python [conda env:optima37]",
+   "display_name": "Python [conda env:atomica37]",
    "language": "python",
-   "name": "conda-env-optima37-py"
+   "name": "conda-env-atomica37-py"
   },
   "language_info": {
    "codemirror_mode": {
@@ -463,7 +463,7 @@
    "name": "python",
    "nbconvert_exporter": "python",
    "pygments_lexer": "ipython3",
-   "version": "3.7.0"
+   "version": "3.7.2"
   },
   "toc": {
    "base_numbering": 1,

--- a/docs/examples/Plotting.ipynb
+++ b/docs/examples/Plotting.ipynb
@@ -2338,9 +2338,9 @@
  ],
  "metadata": {
   "kernelspec": {
-   "display_name": "Python [conda env:optima37]",
+   "display_name": "Python [conda env:atomica37]",
    "language": "python",
-   "name": "conda-env-optima37-py"
+   "name": "conda-env-atomica37-py"
   },
   "language_info": {
    "codemirror_mode": {
@@ -2352,7 +2352,7 @@
    "name": "python",
    "nbconvert_exporter": "python",
    "pygments_lexer": "ipython3",
-   "version": "3.7.0"
+   "version": "3.7.2"
   },
   "toc": {
    "base_numbering": 1,

--- a/tests/test_tox_scenarios.py
+++ b/tests/test_tox_scenarios.py
@@ -269,12 +269,13 @@ def test_overwrite_function_scenario():
     assert np.allclose(var1.vals[var1.t == 2010][0], var2.vals[var2.t == 2010][0], equal_nan=True)
     assert np.allclose(var2.vals[var2.t == 2015][0], 0.1, equal_nan=True)
     assert np.allclose(var2.vals[var2.t == 2018][0], 0.15, equal_nan=True)
+    assert np.allclose(var2.vals[var2.t == 2019][0], 0.15, equal_nan=True) # Check that the function didn't turn back on
 
 
     
 if __name__ == '__main__':
     # test_program_scenarios()
     # test_timevarying_progscen()
-    test_parameter_scenarios()
+    # test_parameter_scenarios()
     # test_combined_scenario()
-    # test_overwrite_function_scenario()
+    test_overwrite_function_scenario()

--- a/tests/test_tox_scenarios.py
+++ b/tests/test_tox_scenarios.py
@@ -232,6 +232,36 @@ def test_overwrite_function_scenario():
     assert np.allclose(var2.vals[var2.t == 2015][0], 0.1, equal_nan=True)  # Default tolerances are rtol=1e-05, atol=1e-08
     assert np.allclose(var2.vals[var2.t == 2018][0], 0.15, equal_nan=True)  # Default tolerances are rtol=1e-05, atol=1e-08
 
+def test_parset_inf_time():
+    """
+    Check time values of `np.inf` work correctly
+    
+    The intended behaviour is that if `np.inf` is provided then the 
+    parameter scenario should never end
+    
+    :return: 
+    """
+
+    proj = at.demo('sir', do_run=False)
+    proj.settings.update_time_vector(start=2000, end=2023)
+
+    # Check that it runs with an empty scvalues
+    scvalues = dict()
+
+    # Check that it runs with a single overwrite
+    scen_par1 = "contacts"
+    scen_pop = "adults"
+    scvalues[scen_par1] = dict()
+    scvalues[scen_par1][scen_pop] = dict()
+    scvalues[scen_par1][scen_pop]["y"] = [80., 40, 40]
+    scvalues[scen_par1][scen_pop]["t"] = [2010., 2020., np.inf]
+    scen = proj.make_scenario(which='parameter', scenario_values=scvalues)
+    ps = scen.get_parset(parset=proj.parsets[0], project=proj)
+    
+    # The correct behaviour is that the parameter scenario 
+    
+    
+    
 if __name__ == '__main__':
     # test_program_scenarios()
     # test_timevarying_progscen()

--- a/tests/test_tox_scenarios.py
+++ b/tests/test_tox_scenarios.py
@@ -166,26 +166,26 @@ def test_parameter_scenarios():
     # Check that default is stepped interpolation
     var = scen_results.get_variable(scen_par1,scen_pop)[0]
     assert np.allclose(var.vals[var.t==2010][0], 80, equal_nan=True)  # Default tolerances are rtol=1e-05, atol=1e-08
-    assert np.allclose(var.vals[var.t==2015][0], 80, equal_nan=True)  # Default tolerances are rtol=1e-05, atol=1e-08
-    assert np.allclose(var.vals[var.t==2020][0], 40, equal_nan=True)  # Default tolerances are rtol=1e-05, atol=1e-08
+    assert np.allclose(var.vals[var.t==2015][0], 80, equal_nan=True)
+    assert np.allclose(var.vals[var.t==2020][0], 40, equal_nan=True)
 
     # Check smooth onset when smooth onset is applied
     scvalues[scen_par1][scen_pop]["smooth_onset"] = 2
     scen = proj.make_scenario(which='parameter', scenario_values=scvalues)
     scen_results = scen.run(proj, proj.parsets["default"])
     var = scen_results.get_variable(scen_par1,scen_pop)[0]
-    assert np.allclose(var.vals[var.t == 2018][0], 80, equal_nan=True)  # Default tolerances are rtol=1e-05, atol=1e-08
-    assert np.allclose(var.vals[var.t == 2019][0], 60, equal_nan=True)  # Default tolerances are rtol=1e-05, atol=1e-08
-    assert np.allclose(var.vals[var.t == 2020][0], 40, equal_nan=True)  # Default tolerances are rtol=1e-05, atol=1e-08
+    assert np.allclose(var.vals[var.t == 2018][0], 80, equal_nan=True)
+    assert np.allclose(var.vals[var.t == 2019][0], 60, equal_nan=True)
+    assert np.allclose(var.vals[var.t == 2020][0], 40, equal_nan=True)
 
     # Check smooth onset works if larger than the gap in overwrite
     scvalues[scen_par1][scen_pop]["smooth_onset"] = 11
     scen = proj.make_scenario(which='parameter', scenario_values=scvalues)
     scen_results = scen.run(proj, proj.parsets["default"])
     var = scen_results.get_variable(scen_par1,scen_pop)[0]
-    assert np.allclose(var.vals[var.t == 2010][0], 80, equal_nan=True)  # Default tolerances are rtol=1e-05, atol=1e-08
-    assert np.allclose(var.vals[var.t == 2015][0], 60, equal_nan=True)  # Default tolerances are rtol=1e-05, atol=1e-08
-    assert np.allclose(var.vals[var.t == 2020][0], 40, equal_nan=True)  # Default tolerances are rtol=1e-05, atol=1e-08
+    assert np.allclose(var.vals[var.t == 2010][0], 80, equal_nan=True)
+    assert np.allclose(var.vals[var.t == 2015][0], 60, equal_nan=True)
+    assert np.allclose(var.vals[var.t == 2020][0], 40, equal_nan=True)
 
     # Check that multiple overwrites work
     scen_par2 = "transpercontact"
@@ -199,12 +199,12 @@ def test_parameter_scenarios():
     var1 = scen_results.get_variable(scen_par1,scen_pop)[0]
     var2 = scen_results.get_variable(scen_par2,scen_pop)[0]
 
-    assert np.allclose(var1.vals[var1.t == 2010][0], 80, equal_nan=True)  # Default tolerances are rtol=1e-05, atol=1e-08
-    assert np.allclose(var1.vals[var1.t == 2015][0], 60, equal_nan=True)  # Default tolerances are rtol=1e-05, atol=1e-08
-    assert np.allclose(var1.vals[var1.t == 2020][0], 40, equal_nan=True)  # Default tolerances are rtol=1e-05, atol=1e-08
-    assert np.allclose(var2.vals[var2.t == 2010][0], 0.008, equal_nan=True)  # Default tolerances are rtol=1e-05, atol=1e-08
-    assert np.allclose(var2.vals[var2.t == 2015][0], 0.008, equal_nan=True)  # Default tolerances are rtol=1e-05, atol=1e-08
-    assert np.allclose(var2.vals[var2.t == 2020][0], 0.005, equal_nan=True)  # Default tolerances are rtol=1e-05, atol=1e-08
+    assert np.allclose(var1.vals[var1.t == 2010][0], 80, equal_nan=True)
+    assert np.allclose(var1.vals[var1.t == 2015][0], 60, equal_nan=True)
+    assert np.allclose(var1.vals[var1.t == 2020][0], 40, equal_nan=True)
+    assert np.allclose(var2.vals[var2.t == 2010][0], 0.008, equal_nan=True)
+    assert np.allclose(var2.vals[var2.t == 2015][0], 0.008, equal_nan=True)
+    assert np.allclose(var2.vals[var2.t == 2020][0], 0.005, equal_nan=True)
 
     # Check that scenarios don't end by default
     scen_par1 = "contacts"
@@ -216,17 +216,33 @@ def test_parameter_scenarios():
     scen = proj.make_scenario(which='parameter', scenario_values=scvalues)
     scen_results = scen.run(proj, proj.parsets["default"])
     var = scen_results.get_variable(scen_par1,scen_pop)[0]
-    assert np.allclose(var.vals[var.t==2020][0], 40, equal_nan=True)  # Default tolerances are rtol=1e-05, atol=1e-08
-    assert np.allclose(var.vals[var.t==2021][0], 40, equal_nan=True)  # Default tolerances are rtol=1e-05, atol=1e-08
+    assert np.allclose(var.vals[var.t==2020][0], 40, equal_nan=True)
+    assert np.allclose(var.vals[var.t==2021][0], 40, equal_nan=True)
 
     # Check that scenarios can be ended with the flag
     scvalues[scen_par1][scen_pop]["end_overwrite"] = True
     scen = proj.make_scenario(which='parameter', scenario_values=scvalues)
     scen_results = scen.run(proj, proj.parsets["default"])
     var = scen_results.get_variable(scen_par1,scen_pop)[0]
-    assert np.allclose(var.vals[var.t == 2020][0], 40, equal_nan=True)  # Default tolerances are rtol=1e-05, atol=1e-08
-    assert np.allclose(var.vals[var.t == 2021][0], 80, equal_nan=True)  # Default tolerances are rtol=1e-05, atol=1e-08
+    assert np.allclose(var.vals[var.t == 2020][0], 40, equal_nan=True)
+    assert np.allclose(var.vals[var.t == 2021][0], 80, equal_nan=True)
 
+    # Check that scenarios ending behaves correctly with time-dependent data
+    proj.data.tdve['contacts'].ts['adults'].insert(2015,80)
+    proj.data.tdve['contacts'].ts['adults'].insert(2025,80)
+    parset = at.ParameterSet(proj.framework,proj.data)
+    
+    scen_results = scen.run(proj, parset)
+    var = scen_results.get_variable(scen_par1,scen_pop)[0]
+    assert np.allclose(var.vals[var.t == 2020][0], 40, equal_nan=True)
+    assert np.allclose(var.vals[var.t == 2021][0], 80, equal_nan=True)  # When the scenario ends, it goes back to the 2025 time value, but immediately after 2020
+    
+    scvalues[scen_par1][scen_pop]["end_overwrite"] = False
+    scen = proj.make_scenario(which='parameter', scenario_values=scvalues)
+    scen_results = scen.run(proj, parset)
+    var = scen_results.get_variable(scen_par1, scen_pop)[0]
+    assert np.allclose(var.vals[var.t == 2020][0], 40, equal_nan=True)
+    assert np.allclose(var.vals[var.t == 2021][0], 40, equal_nan=True)  # When the scenario doens't end, the 2025 time value is removed
 
 def test_overwrite_function_scenario():
     proj = at.demo('sir',do_run=False)
@@ -250,9 +266,9 @@ def test_overwrite_function_scenario():
     var1 = baseline.get_variable(scen_par1,scen_pop)[0]
     var2 = scen_results.get_variable(scen_par1,scen_pop)[0]
 
-    assert np.allclose(var1.vals[var1.t == 2010][0], var2.vals[var2.t == 2010][0], equal_nan=True)  # Default tolerances are rtol=1e-05, atol=1e-08
-    assert np.allclose(var2.vals[var2.t == 2015][0], 0.1, equal_nan=True)  # Default tolerances are rtol=1e-05, atol=1e-08
-    assert np.allclose(var2.vals[var2.t == 2018][0], 0.15, equal_nan=True)  # Default tolerances are rtol=1e-05, atol=1e-08
+    assert np.allclose(var1.vals[var1.t == 2010][0], var2.vals[var2.t == 2010][0], equal_nan=True)
+    assert np.allclose(var2.vals[var2.t == 2015][0], 0.1, equal_nan=True)
+    assert np.allclose(var2.vals[var2.t == 2018][0], 0.15, equal_nan=True)
 
 
     

--- a/tests/test_tox_scenarios.py
+++ b/tests/test_tox_scenarios.py
@@ -206,6 +206,28 @@ def test_parameter_scenarios():
     assert np.allclose(var2.vals[var2.t == 2015][0], 0.008, equal_nan=True)  # Default tolerances are rtol=1e-05, atol=1e-08
     assert np.allclose(var2.vals[var2.t == 2020][0], 0.005, equal_nan=True)  # Default tolerances are rtol=1e-05, atol=1e-08
 
+    # Check that scenarios don't end by default
+    scen_par1 = "contacts"
+    scen_pop = "adults"
+    scvalues[scen_par1] = dict()
+    scvalues[scen_par1][scen_pop] = dict()
+    scvalues[scen_par1][scen_pop]["y"] = [80., 40]
+    scvalues[scen_par1][scen_pop]["t"] = [2010., 2020.]
+    scen = proj.make_scenario(which='parameter', scenario_values=scvalues)
+    scen_results = scen.run(proj, proj.parsets["default"])
+    var = scen_results.get_variable(scen_par1,scen_pop)[0]
+    assert np.allclose(var.vals[var.t==2020][0], 40, equal_nan=True)  # Default tolerances are rtol=1e-05, atol=1e-08
+    assert np.allclose(var.vals[var.t==2021][0], 40, equal_nan=True)  # Default tolerances are rtol=1e-05, atol=1e-08
+
+    # Check that scenarios can be ended with the flag
+    scvalues[scen_par1][scen_pop]["end_overwrite"] = True
+    scen = proj.make_scenario(which='parameter', scenario_values=scvalues)
+    scen_results = scen.run(proj, proj.parsets["default"])
+    var = scen_results.get_variable(scen_par1,scen_pop)[0]
+    assert np.allclose(var.vals[var.t == 2020][0], 40, equal_nan=True)  # Default tolerances are rtol=1e-05, atol=1e-08
+    assert np.allclose(var.vals[var.t == 2021][0], 80, equal_nan=True)  # Default tolerances are rtol=1e-05, atol=1e-08
+
+
 def test_overwrite_function_scenario():
     proj = at.demo('sir',do_run=False)
     proj.settings.update_time_vector(start=2000,end=2023)

--- a/tests/test_tox_scenarios.py
+++ b/tests/test_tox_scenarios.py
@@ -232,39 +232,11 @@ def test_overwrite_function_scenario():
     assert np.allclose(var2.vals[var2.t == 2015][0], 0.1, equal_nan=True)  # Default tolerances are rtol=1e-05, atol=1e-08
     assert np.allclose(var2.vals[var2.t == 2018][0], 0.15, equal_nan=True)  # Default tolerances are rtol=1e-05, atol=1e-08
 
-def test_parset_inf_time():
-    """
-    Check time values of `np.inf` work correctly
-    
-    The intended behaviour is that if `np.inf` is provided then the 
-    parameter scenario should never end
-    
-    :return: 
-    """
 
-    proj = at.demo('sir', do_run=False)
-    proj.settings.update_time_vector(start=2000, end=2023)
-
-    # Check that it runs with an empty scvalues
-    scvalues = dict()
-
-    # Check that it runs with a single overwrite
-    scen_par1 = "contacts"
-    scen_pop = "adults"
-    scvalues[scen_par1] = dict()
-    scvalues[scen_par1][scen_pop] = dict()
-    scvalues[scen_par1][scen_pop]["y"] = [80., 40, 40]
-    scvalues[scen_par1][scen_pop]["t"] = [2010., 2020., np.inf]
-    scen = proj.make_scenario(which='parameter', scenario_values=scvalues)
-    ps = scen.get_parset(parset=proj.parsets[0], project=proj)
-    
-    # The correct behaviour is that the parameter scenario 
-    
-    
     
 if __name__ == '__main__':
     # test_program_scenarios()
     # test_timevarying_progscen()
-    # test_parameter_scenarios()
+    test_parameter_scenarios()
     # test_combined_scenario()
-    test_overwrite_function_scenario()
+    # test_overwrite_function_scenario()


### PR DESCRIPTION
This PR makes it so that parameter scenarios now do not end by default. A flag is provided in the scenario values. If `False` (default) then the last scenario value is used until the end of the simulation, whenever that is. If `True`, the scenario ends immediately after the last scenario value, which was previously the default behaviour.

To improve robustness of this feature and other related interpolations, the `pchip` interpolation has been replaced by linear interpolation throughout. Results may be slightly affected, but not significantly. Some plots may occasionally appear more jagged (but this is typically unlikely because existing normal series plots do not use interpolation anyway). The TB model appears to run about 10% faster