### PR TITLE
Update FE optimization variables

### DIFF
--- a/atomica/optimization.py
+++ b/atomica/optimization.py
@@ -624,7 +624,7 @@ class OptimInstructions(NamedItem):
                 limits[0] = 0.0
             if limits[1] is None and optim_type == 'money':
                 # Money minimization requires an absolute upper bound. Limit it to 5x default spend by default
-                limits[1] = 5 * default_spend[prog_name]
+                limits[1] = 10 * default_spend[prog_name]
             adjustments.append(SpendingAdjustment(prog_name, t=adjustment_year, limit_type='abs', lower=limits[0], upper=limits[1]))
 
             if optim_type == 'money':
@@ -666,7 +666,7 @@ class OptimInstructions(NamedItem):
 
         if optim_type == 'money':
             # Do a prerun to convert the optimization targets into absolute units
-            result = proj.run_sim(proj.parsets[parset_name], progset=progset, progset_instructions=progset_instructions, store_results=False)
+            result = proj.run_sim(proj.parsets[parset_name], progset=progset, progset_instructions=ProgramInstructions(alloc=progset, start_year=start_year), store_results=False)
             for measurable in measurables:
                 val = measurable.get_objective_val(result.model)  # This is the baseline value for the quantity being thresholded
                 assert measurable.threshold <= 100 and measurable.threshold >= 0

--- a/atomica/project.py
+++ b/atomica/project.py
@@ -765,9 +765,9 @@ class Project(NamedItem):
 
         elif tool == 'tb':
             if optim_type == 'outcome':
-                json['objective_weights'] = {'ddis': 1, 'acj': 1, 'ds_inf': 0, 'mdr_inf': 0, 'xdr_inf': 0}  # These are TB-specific: maximize people alive, minimize people dead due to TB
-                json['objective_labels'] = {'ddis': 'Minimize TB-related deaths',
-                                            'acj': 'Minimize total new active TB infections',
+                json['objective_weights'] = {'ddis:': 1, ':acj': 1, 'ds_inf': 0, 'mdr_inf': 0, 'xdr_inf': 0}  # These are TB-specific: maximize people alive, minimize people dead due to TB
+                json['objective_labels'] = {'ddis:': 'Minimize TB-related deaths',
+                                            ':acj': 'Minimize total new active TB infections',
                                             'ds_inf': 'Minimize prevalence of active DS-TB',
                                             'mdr_inf': 'Minimize prevalence of active MDR-TB',
                                             'xdr_inf': 'Minimize prevalence of active XDR-TB'}
@@ -775,9 +775,9 @@ class Project(NamedItem):
                 # The weights here default to 0 because it's possible, depending on what programs are selected, that improvement
                 # in one or more of them might be impossible even with infinite money. Also, can't increase money too much because otherwise
                 # run the risk of a local minimum stopping optimization early with the current algorithm (this will change in the future)
-                json['objective_weights'] = {'ddis': 0, 'acj': 5, 'ds_inf': 0, 'mdr_inf': 0, 'xdr_inf': 0}  # These are TB-specific: maximize people alive, minimize people dead due to TB
-                json['objective_labels'] = {'ddis': 'Minimize TB-related deaths',
-                                            'acj': 'Total new active TB infections',
+                json['objective_weights'] = {':ddis': 0, ':acj': 5, 'ds_inf': 0, 'mdr_inf': 0, 'xdr_inf': 0}  # These are TB-specific: maximize people alive, minimize people dead due to TB
+                json['objective_labels'] = {':ddis': 'Minimize TB-related deaths',
+                                            ':acj': 'Total new active TB infections',
                                             'ds_inf': 'Prevalence of active DS-TB',
                                             'mdr_inf': 'Prevalence of active MDR-TB',
                                             'xdr_inf': 'Prevalence of active XDR-TB'}

--- a/atomica/project.py
+++ b/atomica/project.py
@@ -765,8 +765,9 @@ class Project(NamedItem):
 
         elif tool == 'tb':
             if optim_type == 'outcome':
-                json['objective_weights'] = {'ddis:': 1, ':acj': 1, 'ds_inf': 0, 'mdr_inf': 0, 'xdr_inf': 0}  # These are TB-specific: maximize people alive, minimize people dead due to TB
-                json['objective_labels'] = {'ddis:': 'Minimize TB-related deaths',
+                json['objective_weights'] = {'daly_rate': 0, ':ddis': 1, ':acj': 1, 'ds_inf': 0, 'mdr_inf': 0, 'xdr_inf': 0}  # These are TB-specific: maximize people alive, minimize people dead due to TB
+                json['objective_labels'] = {'daly_rate': 'Minimize DALYs',
+                                            ':ddis': 'Minimize TB-related deaths',
                                             ':acj': 'Minimize total new active TB infections',
                                             'ds_inf': 'Minimize prevalence of active DS-TB',
                                             'mdr_inf': 'Minimize prevalence of active MDR-TB',
@@ -775,8 +776,9 @@ class Project(NamedItem):
                 # The weights here default to 0 because it's possible, depending on what programs are selected, that improvement
                 # in one or more of them might be impossible even with infinite money. Also, can't increase money too much because otherwise
                 # run the risk of a local minimum stopping optimization early with the current algorithm (this will change in the future)
-                json['objective_weights'] = {':ddis': 0, ':acj': 5, 'ds_inf': 0, 'mdr_inf': 0, 'xdr_inf': 0}  # These are TB-specific: maximize people alive, minimize people dead due to TB
-                json['objective_labels'] = {':ddis': 'Minimize TB-related deaths',
+                json['objective_weights'] = {'daly_rate': 0, ':ddis': 0, ':acj': 5, 'ds_inf': 0, 'mdr_inf': 0, 'xdr_inf': 0}  # These are TB-specific: maximize people alive, minimize people dead due to TB
+                json['objective_labels'] = {'daly_rate': 'Minimize DALYs',
+                                            ':ddis': 'Minimize TB-related deaths',
                                             ':acj': 'Total new active TB infections',
                                             'ds_inf': 'Prevalence of active DS-TB',
                                             'mdr_inf': 'Prevalence of active MDR-TB',


### PR DESCRIPTION
This PR updates the optimization variables to use flows instead of compartments for `ddis` and `acj`. In particular, `acj` is always `0` so it had no effect previously, whereas `:acj` (the flow into the active junction) is more appropriate to use