### PR TITLE
Calibration tweaks

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,10 @@
 # Changelog
 
+This file records changes to the codebase grouped by version release. Unreleased changes are generally only present during development (relevant parts of the changelog can be written and saved in that section before a version number has been assigned)
+
+## [Unreleased]
+
+
 ## [1.19.0] - 2020-06-26
 
 - Renamed `calibration.py:perform_autofit()` to `calibration.py:calibrate()`

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,0 +1,7 @@
+# Changelog
+
+## [1.19.0] - 2020-06-26
+
+- Renamed `calibration.py:perform_autofit()` to `calibration.py:calibrate()`
+- Added debug-level log messages, which can be viewed by setting `atomica.logger.setLevel(1)`
+- Added changelog

--- a/atomica/__init__.py
+++ b/atomica/__init__.py
@@ -56,16 +56,23 @@ if not logger.hasHandlers():
     # prior to importing Atomica, and the user's custom logger won't be overwritten as long as it has
     # at least one handler already added. The use case was originally to suppress messages on import, but since
     # importing is silent now, it doesn't matter so much.
-    h1 = logging.StreamHandler(sys.stdout) # h1 will handle all messages below WARNING sending them to STDOUT
-    h2 = logging.StreamHandler(sys.stderr) # h2 will send all messages at or above WARNING to STDERR
+    debug_handler = logging.StreamHandler(sys.stdout) # info_handler will handle all messages below WARNING sending them to STDOUT
+    info_handler = logging.StreamHandler(sys.stdout) # info_handler will handle all messages below WARNING sending them to STDOUT
+    warning_handler = logging.StreamHandler(sys.stderr) # warning_handler will send all messages at or above WARNING to STDERR
 
-    h1.setLevel(0)  # Handle all lower levels - the output should be filtered further by setting the logger level, not the handler level
-    warning_level = logging.WARNING
-    h1.addFilter(type("ThresholdFilter", (object,), {"filter": lambda x, logRecord: logRecord.levelno < warning_level})())  # Display anything less than a warning
-    h2.setLevel(logging.WARNING)
+    debug_handler.setLevel(0)  # Handle all lower levels - the output should be filtered further by setting the logger level, not the handler level
+    info_handler.setLevel(logging.INFO)  # Handle all lower levels - the output should be filtered further by setting the logger level, not the handler level
+    warning_handler.setLevel(logging.WARNING)
 
-    logger.addHandler(h1)
-    logger.addHandler(h2)
+    debug_handler.addFilter(type("ThresholdFilter", (object,), {"filter": lambda x, logRecord: logRecord.levelno < logging.INFO})())  # Display anything INFO or higher
+    info_handler.addFilter(type("ThresholdFilter", (object,), {"filter": lambda x, logRecord: logRecord.levelno < logging.WARNING})())  # Don't display WARNING or higher
+
+    debug_formatter = logging.Formatter('%(levelname)s {%(filename)s:%(lineno)d} - %(message)s')
+    debug_handler.setFormatter(debug_formatter)
+
+    logger.addHandler(debug_handler)
+    logger.addHandler(info_handler)
+    logger.addHandler(warning_handler)
     logger.setLevel('INFO') # Set the overall log level
 
 from .version import version as __version__, versiondate as __versiondate__, gitinfo as __gitinfo__

--- a/atomica/framework.py
+++ b/atomica/framework.py
@@ -1140,7 +1140,7 @@ class ProjectFramework(object):
                     A[i, comps.index(include)] = 1.0
 
             if np.linalg.matrix_rank(A) < len(comps):
-                logger.warning('Initialization characteristics are underdetermined - this may be intentional, but check the initial compartment sizes carefully')
+                logger.debug('Initialization characteristics are underdetermined - this may be intentional, but check the initial compartment sizes carefully')
 
         # ASSIGN DURATION GROUPS
         # This needs to be done for compartments, as well as junctions

--- a/atomica/plotting.py
+++ b/atomica/plotting.py
@@ -88,7 +88,8 @@ def save_figs(figs, path='.', prefix='', fnames=None) -> None:
         if not fnames[i]:  # assert above means that i>0
             fnames[i] = fnames[i - 1] + '_legend'
             legend = fig.findobj(Legend)[0]
-            fig.canvas.draw()
+            renderer = fig.canvas.get_renderer()
+            fig.draw(renderer=renderer)
             bbox = legend.get_window_extent().transformed(fig.dpi_scale_trans.inverted())
         else:
             bbox = 'tight'

--- a/atomica/programs.py
+++ b/atomica/programs.py
@@ -460,7 +460,7 @@ class ProgramSet(NamedItem):
         self = ProgramSet(name=name, framework=framework, data=data)
 
         # Create and load spreadsheet
-        if sc.isstring(spreadsheet):
+        if not isinstance(spreadsheet, sc.Spreadsheet):
             spreadsheet = sc.Spreadsheet(spreadsheet)
 
         workbook = openpyxl.load_workbook(spreadsheet.tofile(), read_only=True, data_only=True)  # Load in read-only mode for performance, since we don't parse comments etc.

--- a/atomica/project.py
+++ b/atomica/project.py
@@ -19,7 +19,7 @@ In addition, a project contains:
 """
 
 from .version import version, gitinfo
-from .calibration import perform_autofit
+from .calibration import calibrate
 from .data import ProjectData
 from .framework import ProjectFramework
 from .model import run_model
@@ -594,7 +594,9 @@ class Project(NamedItem):
 
         if parset is None:
             parset = -1
-        parset = self.parsets[parset]
+        elif not isinstance(parset, ParameterSet):
+            parset = self.parsets[parset]
+
         if new_name is None:
             new_name = parset.name + ' (auto-calibrated)'
         if adjustables is None:
@@ -610,8 +612,8 @@ class Project(NamedItem):
         for index, measurable in enumerate(measurables):
             if sc.isstring(measurable):  # Assume that a parameter name was passed in if not a tuple.
                 measurables[index] = (measurable, None, default_weight, default_metric)
-        new_parset = perform_autofit(project=self, parset=parset,
-                                     pars_to_adjust=adjustables, output_quantities=measurables, max_time=max_time)
+        new_parset = calibrate(project=self, parset=parset,
+                               pars_to_adjust=adjustables, output_quantities=measurables, max_time=max_time)
         new_parset.name = new_name  # The new parset is a calibrated copy of the old, so change id.
         if save_to_project:
             self.parsets.append(new_parset)

--- a/atomica/version.py
+++ b/atomica/version.py
@@ -5,6 +5,6 @@ Standard location for module version number and date.
 """
 
 from .utils import fast_gitinfo
-version = "1.18.5"
-versiondate = "2020-05-25"
+version = "1.19.0"
+versiondate = "2020-06-26"
 gitinfo = fast_gitinfo(__file__)

--- a/atomica/version.py
+++ b/atomica/version.py
@@ -5,6 +5,6 @@ Standard location for module version number and date.
 """
 
 from .utils import fast_gitinfo
-version = "1.18.4"
-versiondate = "2020-05-21"
+version = "1.18.5"
+versiondate = "2020-05-25"
 gitinfo = fast_gitinfo(__file__)

--- a/tests/test_api_workflow.py
+++ b/tests/test_api_workflow.py
@@ -97,7 +97,7 @@ pars_to_adjust = [('transpercontact', 'adults', 0.1, 1.9)]
 output_quantities = []
 for pop in P.parsets[0].pop_names:
     output_quantities.append(('ch_prev', pop, 1.0, "fractional"))
-calibrated_parset = at.perform_autofit(P, P.parsets[0], pars_to_adjust, output_quantities, max_time=30)
+calibrated_parset = at.calibrate(P, P.parsets[0], pars_to_adjust, output_quantities, max_time=30)
 
 # Plot the results before and after calibration
 calibrated_results = P.run_sim(calibrated_parset)


### PR DESCRIPTION
This PR mainly tweaks calibration 

- Rename `at.perform_autofit` to `at.calibrate`. This matches the existing `Project.calibrate` method, as well as better aligns with `at.optimize` 
- Improve logging granularity - extra messages are now printed at the `DEBUG` logger level and can be accessed by changing the logger level e.g. `atomica.logger.setLevel(1)`