### PR TITLE
Add extra condition for making parameter dynamic based on programs

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,10 @@
 
 This file records changes to the codebase grouped by version release. Unreleased changes are generally only present during development (relevant parts of the changelog can be written and saved in that section before a version number has been assigned)
 
+## [1.23.4] - 2020-12-14
+
+- Fix bug where program outcomes were not correctly applied if overwriting a function parameter that does not impact any transitions
+
 ## [1.23.3] - 2020-11-10
 
 - Added `at.stop_logging()` and an optional `reset` argument to `at.start_logging()`

--- a/atomica/model.py
+++ b/atomica/model.py
@@ -1671,7 +1671,7 @@ class Population:
                 links = self.links
 
             if par:
-                links = [link for link in links if link.parameter.name == par]
+                links = [link for link in links if (link.parameter and link.parameter.name == par)]
 
             return links
         else:
@@ -1816,7 +1816,7 @@ class Population:
         # A timed parameter doesn't _directly_ have links associated with it (because it does not supply values
         # for the links) but it does need to be precomputed
         for par in self.pars:
-            if par.fcn_str and (par.links or par.derivative or framework.pars.at[par.name, "timed"] == "y"):
+            if par.fcn_str and (par.links or par.derivative or framework.pars.at[par.name, "timed"] == "y" or (progset is not None and (par.name, self.name) in progset.covouts)):
                 par.set_dynamic(progset)
 
     def initialize_compartments(self, parset: ParameterSet, framework, t_init: float) -> None:

--- a/atomica/version.py
+++ b/atomica/version.py
@@ -6,6 +6,6 @@ Standard location for module version number and date.
 
 from .utils import fast_gitinfo
 
-version = "1.23.3"
-versiondate = "2020-11-10"
+version = "1.23.4"
+versiondate = "2020-12-14"
 gitinfo = fast_gitinfo(__file__)


### PR DESCRIPTION
This PR fixes an unusual edge case, if a parameter had a function and is targetable but does not directly or indirectly drive any transitions. In that case, the parameter would not be considered dynamic and although programs get evaluated at every timestep, the parameter function would overwrite the program outcomes at the end of integration. This PR makes it so that if a parameter is targeted by the Progset, then it is considered dynamic so that the function is precomputed and the program outcomes are not overwritten