### PR TITLE
Fix deprecations and coverage

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,10 @@
 
 This file records changes to the codebase grouped by version release. Unreleased changes are generally only present during development (relevant parts of the changelog can be written and saved in that section before a version number has been assigned)
 
+## [1.25.5] - 2021-07-08
+- Replace deprecated ``sc.SItickformatter`` usage
+- Fix bug in program coverage overwrite timestep scaling. Coverage overwrites must always be provided in dimensionless units
+
 ## [1.25.4] - 2021-06-28
 
 - Improved framework validation (informative errors raised in some additional cases)

--- a/atomica/plotting.py
+++ b/atomica/plotting.py
@@ -1345,7 +1345,7 @@ def plot_bars(plotdata, stack_pops=None, stack_outputs=None, outer=None, legend_
         ax.set_yticks([x[0] for x in block_labels])
         ax.set_yticklabels([x[1] for x in block_labels])
         ax.invert_yaxis()
-        sc.SIticks(ax, axis='x')
+        sc.SIticks(ax, axis="x")
     else:
         ax.set_xlim(left=-2 * gaps[0], right=block_offset + base_offset)
         fig.set_figwidth(1.1 + 1.1 * (block_offset + base_offset))
@@ -1356,7 +1356,7 @@ def plot_bars(plotdata, stack_pops=None, stack_outputs=None, outer=None, legend_
             ax.spines["top"].set_position("zero")
         ax.set_xticks([x[0] for x in block_labels])
         ax.set_xticklabels([x[1] for x in block_labels])
-        sc.SIticks(ax, axis='y')
+        sc.SIticks(ax, axis="y")
 
     # Calculate the units. As all bar patches are shown on the same axis, they are all expected to have the
     # same units. If they do not, the plot could be misleading
@@ -1637,7 +1637,7 @@ def _apply_series_formatting(ax, plot_type) -> None:
         ax.set_ylabel("Proportion " + ax.get_ylabel())
     else:
         ax.set_ylim(top=ax.get_ylim()[1] * 1.05)
-    sc.SIticks(ax, axis='y')
+    sc.SIticks(ax, axis="y")
 
 
 def _turn_off_border(ax) -> None:

--- a/atomica/plotting.py
+++ b/atomica/plotting.py
@@ -846,6 +846,8 @@ class PlotData:
             plotdata.outputs[key] = results[0].model.progset.programs[key].label if key in results[0].model.progset.programs else key
 
         if t_bins is not None:
+            # TODO - time aggregation of coverage_number by integration should only be applied to one-off programs
+            # TODO - confirm time aggregation of spending is correct for the units entered in databook or in overwrites
             if quantity in {"spending", "equivalent_spending", "coverage_number"}:
                 plotdata.time_aggregate(t_bins, "integrate", interpolation_method="previous")
             elif quantity in {"coverage_eligible", "coverage_fraction"}:
@@ -1343,7 +1345,7 @@ def plot_bars(plotdata, stack_pops=None, stack_outputs=None, outer=None, legend_
         ax.set_yticks([x[0] for x in block_labels])
         ax.set_yticklabels([x[1] for x in block_labels])
         ax.invert_yaxis()
-        ax.xaxis.set_major_formatter(FuncFormatter(sc.SItickformatter))
+        sc.SIticks(ax, axis='x')
     else:
         ax.set_xlim(left=-2 * gaps[0], right=block_offset + base_offset)
         fig.set_figwidth(1.1 + 1.1 * (block_offset + base_offset))
@@ -1354,7 +1356,7 @@ def plot_bars(plotdata, stack_pops=None, stack_outputs=None, outer=None, legend_
             ax.spines["top"].set_position("zero")
         ax.set_xticks([x[0] for x in block_labels])
         ax.set_xticklabels([x[1] for x in block_labels])
-        ax.yaxis.set_major_formatter(FuncFormatter(sc.SItickformatter))
+        sc.SIticks(ax, axis='y')
 
     # Calculate the units. As all bar patches are shown on the same axis, they are all expected to have the
     # same units. If they do not, the plot could be misleading
@@ -1635,7 +1637,7 @@ def _apply_series_formatting(ax, plot_type) -> None:
         ax.set_ylabel("Proportion " + ax.get_ylabel())
     else:
         ax.set_ylim(top=ax.get_ylim()[1] * 1.05)
-    ax.yaxis.set_major_formatter(FuncFormatter(sc.SItickformatter))
+    sc.SIticks(ax, axis='y')
 
 
 def _turn_off_border(ax) -> None:

--- a/atomica/programs.py
+++ b/atomica/programs.py
@@ -1046,7 +1046,7 @@ class ProgramSet(NamedItem):
 
         return capacities
 
-    def get_prop_coverage(self, tvec, capacities: dict, num_eligible: dict, dt: float, instructions=None) -> dict:
+    def get_prop_coverage(self, tvec, capacities: dict, num_eligible: dict, instructions=None) -> dict:
         """
         Return fractional coverage
 
@@ -1082,12 +1082,8 @@ class ProgramSet(NamedItem):
                 # timestep coverage to use for each program, not the annual coverage
                 prop_coverage[prog.name] = prog.get_prop_covered(tvec, capacities[prog.name], num_eligible[prog.name])
             else:
+                # Note that coverage overwrites are specified in dimensionless units, therefore no dt adjustment is made here
                 prop_coverage[prog.name] = instructions.coverage[prog.name].interpolate(tvec, method="previous")
-                if prog.is_one_off:
-                    # Scale by dt beforehand, so that a timestep coverage of 1 can be achieved with an annual coverage
-                    # greater than 1 - that is, the number of people covered in a year relative to the CURRENT
-                    # compartment size
-                    prop_coverage[prog.name] *= dt
                 prop_coverage[prog.name] = minimum(prop_coverage[prog.name], 1.0)
 
         return prop_coverage

--- a/atomica/programs.py
+++ b/atomica/programs.py
@@ -1069,7 +1069,6 @@ class ProgramSet(NamedItem):
                            Note that since the capacity and eligible compartment sizes are being compared here,
                            the capacity needs to be in units of 'people' (not 'people/year') at this point
         :param num_eligible: dict of number of people covered by each program, computed externally and with one entry for each program
-        :param dt: simulation timestep
         :param instructions: optionally specify instructions, which can supply a coverage overwrite
         :return: Dict like ``{prog_name: np.array()}`` with fractional coverage values (dimensionless)
 

--- a/atomica/reconciliation.py
+++ b/atomica/reconciliation.py
@@ -151,7 +151,7 @@ def _prepare_asd_inputs(progset, bounds):
 def _objective(x, mapping, progset, eval_years, target_vals, num_eligible, dt):
     _update_progset(x, mapping, progset)  # Apply the changes to the progset
     capacities = progset.get_capacities(tvec=eval_years, dt=dt)  # Get number coverage using latest unit costs but default spending
-    prop_coverage = progset.get_prop_coverage(tvec=eval_years, capacities=capacities, num_eligible=num_eligible, dt=dt)
+    prop_coverage = progset.get_prop_coverage(tvec=eval_years, capacities=capacities, num_eligible=num_eligible)
 
     obj = 0.0
     for i in range(0, len(eval_years)):
@@ -304,8 +304,8 @@ def reconcile(project, parset, progset, reconciliation_year: float, max_time=10,
     records = []
     old_capacities = progset.get_capacities(tvec=eval_years, dt=project.settings.sim_dt)
     new_capacities = new_progset.get_capacities(tvec=eval_years, dt=project.settings.sim_dt)
-    old_prop_coverage = progset.get_prop_coverage(tvec=eval_years, capacities=old_capacities, num_eligible=num_eligible, dt=project.settings.sim_dt)
-    new_prop_coverage = new_progset.get_prop_coverage(tvec=eval_years, capacities=new_capacities, num_eligible=num_eligible, dt=project.settings.sim_dt)
+    old_prop_coverage = progset.get_prop_coverage(tvec=eval_years, capacities=old_capacities, num_eligible=num_eligible)
+    new_prop_coverage = new_progset.get_prop_coverage(tvec=eval_years, capacities=new_capacities, num_eligible=num_eligible)
     for i, year in enumerate(eval_years):
         old_outcomes = progset.get_outcomes(prop_coverage={prog: cov[[i]] for prog, cov in old_prop_coverage.items()})  # Program outcomes for this year
         new_outcomes = new_progset.get_outcomes(prop_coverage={prog: cov[[i]] for prog, cov in new_prop_coverage.items()})  # Program outcomes for this year

--- a/atomica/results.py
+++ b/atomica/results.py
@@ -269,7 +269,7 @@ class Result(NamedItem):
             # Note that `ProgramSet.get_prop_coverage()` takes in capacity in units of 'people' which matches
             # the units of 'num_eligible' so we therefore use the returned value from `ProgramSet.get_capacities()`
             # as-is without doing any annualization
-            prop_coverage = self.model.progset.get_prop_coverage(tvec=self.t, capacities=capacities, num_eligible=num_eligible, dt=self.dt, instructions=self.model.program_instructions)
+            prop_coverage = self.model.progset.get_prop_coverage(tvec=self.t, capacities=capacities, num_eligible=num_eligible, instructions=self.model.program_instructions)
 
             if quantity in {"fraction", "annual_fraction"}:
                 output = prop_coverage

--- a/atomica/version.py
+++ b/atomica/version.py
@@ -6,6 +6,6 @@ Standard location for module version number and date.
 
 from .utils import fast_gitinfo
 
-version = "1.25.4"
-versiondate = "2021-06-28"
+version = "1.25.5"
+versiondate = "2021-07-08"
 gitinfo = fast_gitinfo(__file__)

--- a/setup.py
+++ b/setup.py
@@ -39,5 +39,16 @@ setup(
     classifiers=CLASSIFIERS,
     packages=find_packages(),
     include_package_data=True,
-    install_requires=["matplotlib>=3.0,<=3.3.4", "numpy>=1.10.1", "scipy>=1.2.1", "pandas", "xlsxwriter", "openpyxl", "pyswarm", "hyperopt", "sciris", "tqdm"],
+    install_requires=[
+        "matplotlib>=3.0,<=3.3.4",
+        "numpy>=1.10.1",
+        "scipy>=1.2.1",
+        "pandas<1.2.5",
+        "xlsxwriter",
+        "openpyxl",
+        "pyswarm",
+        "hyperopt",
+        "sciris",
+        "tqdm",
+    ],
 )


### PR DESCRIPTION
- Replace deprecated ``sc.SItickformatter`` usage
- Fix bug in program coverage overwrite timestep scaling. Coverage overwrites must always be provided in dimensionless units