### PR TITLE
Update SIticks to use function instead of formatter

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,10 @@
 
 This file records changes to the codebase grouped by version release. Unreleased changes are generally only present during development (relevant parts of the changelog can be written and saved in that section before a version number has been assigned)
 
+## [1.25.5] - 2021-07-21
+
+- Updated plotting to avoid deprecated Sciris functions
+
 ## [1.25.4] - 2021-06-28
 
 - Improved framework validation (informative errors raised in some additional cases)

--- a/atomica/plotting.py
+++ b/atomica/plotting.py
@@ -26,7 +26,7 @@ from matplotlib.ticker import FuncFormatter
 
 import atomica
 import sciris as sc
-from .model import Compartment, Characteristic, Parameter, Link, TimedLink, SourceCompartment, JunctionCompartment, SinkCompartment
+from .model import Compartment, Characteristic, Parameter, Link, SourceCompartment, JunctionCompartment, SinkCompartment
 from .results import Result
 from .system import logger, NotFoundError
 from .function_parser import parse_function
@@ -1343,7 +1343,7 @@ def plot_bars(plotdata, stack_pops=None, stack_outputs=None, outer=None, legend_
         ax.set_yticks([x[0] for x in block_labels])
         ax.set_yticklabels([x[1] for x in block_labels])
         ax.invert_yaxis()
-        ax.xaxis.set_major_formatter(FuncFormatter(sc.SItickformatter))
+        sc.SIticks(ax=ax, axis='x')
     else:
         ax.set_xlim(left=-2 * gaps[0], right=block_offset + base_offset)
         fig.set_figwidth(1.1 + 1.1 * (block_offset + base_offset))
@@ -1354,7 +1354,7 @@ def plot_bars(plotdata, stack_pops=None, stack_outputs=None, outer=None, legend_
             ax.spines["top"].set_position("zero")
         ax.set_xticks([x[0] for x in block_labels])
         ax.set_xticklabels([x[1] for x in block_labels])
-        ax.yaxis.set_major_formatter(FuncFormatter(sc.SItickformatter))
+        sc.SIticks(ax=ax, axis='y')
 
     # Calculate the units. As all bar patches are shown on the same axis, they are all expected to have the
     # same units. If they do not, the plot could be misleading
@@ -1635,7 +1635,7 @@ def _apply_series_formatting(ax, plot_type) -> None:
         ax.set_ylabel("Proportion " + ax.get_ylabel())
     else:
         ax.set_ylim(top=ax.get_ylim()[1] * 1.05)
-    ax.yaxis.set_major_formatter(FuncFormatter(sc.SItickformatter))
+    sc.SIticks(ax=ax, axis='y')
 
 
 def _turn_off_border(ax) -> None:

--- a/atomica/version.py
+++ b/atomica/version.py
@@ -6,6 +6,6 @@ Standard location for module version number and date.
 
 from .utils import fast_gitinfo
 
-version = "1.25.4"
-versiondate = "2021-06-28"
+version = "1.25.5"
+versiondate = "2021-07-21"
 gitinfo = fast_gitinfo(__file__)


### PR DESCRIPTION
Updates the plotting code to use `sc.SIticks()`, rather than `sc.SItickformatter()`, which is an internal which wasn't intended to be used directly. For compatibility with Sciris >=1.2.1. But should be fully backwards compatible, too.