### PR TITLE
Fix ResidualJunctionCompartment not applying stochasticity correctly

### DIFF
--- a/atomica/model.py
+++ b/atomica/model.py
@@ -228,7 +228,7 @@ class Variable:
 class Compartment(Variable):
     """A class to wrap up data for one compartment within a cascade network."""
 
-    def __init__(self, pop, name, stochastic:bool = False, rng_sampler = None):
+    def __init__(self, pop, name, stochastic: bool = False, rng_sampler = None):
         Variable.__init__(self, pop=pop, id=(pop.name, name))
         self.units = "Number of people"
         self.outlinks = []

--- a/atomica/parameters.py
+++ b/atomica/parameters.py
@@ -90,7 +90,7 @@ class Parameter(NamedItem):
 
         return self.ts[pop_name].interpolate(tvec, method=self._interpolation_method)
 
-    def sample(self, constant: bool, rng_sampler = None) -> None:
+    def sample(self, constant: bool, rng_sampler=None) -> None:
         """
         Perturb parameter based on uncertainties
 

--- a/atomica/programs.py
+++ b/atomica/programs.py
@@ -1198,7 +1198,7 @@ class Program(NamedItem):
         """
         return "/year" not in self.unit_cost.units
 
-    def sample(self, constant: bool, rng_sampler = None) -> None:
+    def sample(self, constant: bool, rng_sampler=None) -> None:
         """
         Perturb program values based on uncertainties
 

--- a/atomica/project.py
+++ b/atomica/project.py
@@ -67,7 +67,7 @@ class ProjectSettings:
     @property
     def sim_dt(self):
         return self._sim_dt
-    
+
     @property
     def stochastic(self):
         return self._stochastic


### PR DESCRIPTION
The trouble was with a ">" residual link.

 - `outflow` wasn't updated with the stochastic `outflow_fractions`, and
 - The probabilities need to sum to 1 in a multinomial so we give the residual probability to the residual link
 
Also, this checks that net_inflow is an integer and throws an error if it is not. The other links coming into the ResidualJunctionCompartment should have integer flows when `stochastic = True` but I'm not sure it is appropriate to check this here and throw an error?
