### PR TITLE
Catch model exceptions and add info before re-raising

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,10 @@
 
 This file records changes to the codebase grouped by version release. Unreleased changes are generally only present during development (relevant parts of the changelog can be written and saved in that section before a version number has been assigned)
 
+## [1.26.4] - 2023-08-25
+
+- Some numerical errors in `model.py` (particularly relating to errors/warnings in parameter functions) are now caught and printed with more informative error messages. 
+
 ## [1.26.3] - 2023-07-18
 
 - Change the table parsing routine again to resolve further edge cases, restore removal of leading and trailing spaces from cells in the framework, and improve performance. The original `None` behaviour has consequently been restored (undoing the change in 1.26.2) although it is still recommended that `pandas.isna()` is used instead of checking for `None`.

--- a/atomica/model.py
+++ b/atomica/model.py
@@ -1273,8 +1273,8 @@ class Parameter(Variable):
         dep_vals["dt"] = self.dt
         try:
             v = self.scale_factor * self._fcn(**dep_vals)
-        except:
-            raise ModelError(f"Error when calculating the value for parameter: {self}")
+        except Exception as e:
+            raise ModelError(f"Error when calculating the value for parameter: {self}") from e
 
         if self.derivative:
             self._dx = v

--- a/atomica/model.py
+++ b/atomica/model.py
@@ -519,9 +519,9 @@ class JunctionCompartment(Compartment):
         # Finally, assign the inflow to the outflow proportionately accounting for the total outflow downscaling
         for frac, link in zip(outflow_fractions, self.outlinks):
             if self.duration_group:
-                link._vals[:, ti] = net_inflow * frac / total_outflow  #HERE? - taken care of
+                link._vals[:, ti] = net_inflow * frac / total_outflow
             else:
-                link.vals[ti] = net_inflow * frac / total_outflow  #HERE? - taken care of
+                link.vals[ti] = net_inflow * frac / total_outflow
 
     def initial_flush(self) -> None:
         """
@@ -540,7 +540,7 @@ class JunctionCompartment(Compartment):
         if self.vals[0] > 0:
             # Work out the outflow fractions
             outflow_fractions = np.array([link.parameter.vals[0] for link in self.outlinks])
-            outflow_fractions /= np.sum(outflow_fractions)  #HERE? - taken care of
+            outflow_fractions /= np.sum(outflow_fractions)
 
             # Assign the inflow directly to the outflow compartments
             # This is done using the [] indexing on the downstream compartment so it is agnostic
@@ -1114,7 +1114,7 @@ class Parameter(Variable):
 
         assert sc.isstring(fcn_str), "Parameter function must be supplied as a string"
         self.fcn_str = fcn_str
-        self._fcn, dep_list = parse_function(self.fcn_str)  # HERE2
+        self._fcn, dep_list = parse_function(self.fcn_str)
         if fcn_str.startswith("SRC_POP_AVG") or fcn_str.startswith("TGT_POP_AVG") or fcn_str.startswith("SRC_POP_SUM") or fcn_str.startswith("TGT_POP_SUM"):
             # The function is like 'SRC_POP_AVG(par_name,interaction_name,charac_name)'
             # self.pop_aggregation will be ['SRC_POP_AVG',par_name,interaction_name,charac_object]
@@ -1200,7 +1200,7 @@ class Parameter(Variable):
             for dep_name in self.deps:
                 self.deps[dep_name] = [objs[x] for x in self.deps[dep_name]]
         if self.fcn_str:
-            self._fcn = parse_function(self.fcn_str)[0]  ##HERE 2
+            self._fcn = parse_function(self.fcn_str)[0]
 
     def constrain(self, ti=None) -> None:
         """
@@ -2431,7 +2431,7 @@ class Model:
                 # to be able to correctly convert between timescales. The subsequent call to min() then ensures that the fraction moved never
                 # exceeds 1.0 once operating on the timestep level
                 try:
-                    converted_frac = transition * (self.dt / par.timescale)  #HERE? - done
+                    converted_frac = transition * (self.dt / par.timescale)
                 except Exception as e:
                     raise ModelError(f"Error when converting the parameter {par} to a per timestep value.") from e
                 for link in par.links:
@@ -2441,9 +2441,10 @@ class Model:
             elif par.units == FS.QUANTITY_TYPE_NUMBER:
                 # Disaggregate proportionally across all source compartment sizes related to all links.
                 try:
-                    converted_amt = transition * (self.dt / par.timescale)  #HERE?  - done # Number flow in this timestep, so it includes a timescale factor
+                    converted_amt = transition * (self.dt / par.timescale)  # Number flow in this timestep, so it includes a timescale factor
                 except Exception as e:
                     raise ModelError(f"Error when converting the parameter {par} to a per timestep value.") from e
+
                 if isinstance(par.links[0].source, SourceCompartment):
                     # For a source compartment, the link value should be explicitly set directly
                     # Also, there is guaranteed to only be one link per parameter for outflows from source compartments
@@ -2462,7 +2463,7 @@ class Model:
             # Convert from duration to equivalent probability
             elif par.units == FS.QUANTITY_TYPE_DURATION:
                 try:
-                    converted_frac = self.dt / (transition * par.timescale)  #HERE? - done
+                    converted_frac = self.dt / (transition * par.timescale)
                 except Exception as e:
                     raise ModelError(f"Error when converting the parameter {par} to a per timestep value.") from e
                 for link in par.links:

--- a/atomica/version.py
+++ b/atomica/version.py
@@ -6,6 +6,6 @@ Standard location for module version number and date.
 
 import sciris as sc
 
-version = "1.26.3"
-versiondate = "2023-07-18"
+version = "1.26.4"
+versiondate = "2023-08-25"
 gitinfo = sc.gitinfo(__file__)


### PR DESCRIPTION
Add information about which parameter or junction is causing an error - with the errors mainly being caused by: ``with np.errstate(all='raise'):``

I went through and found all the uses of ``parse_function()`` where the output function ``fcn`` is then called - which turns out to only be in ``Parameter.update()``

I also went through ``model.py`` and found all divisions without a check for a divide by zero beforehand.