### PR TITLE
Allow transfer duration units, improved error handling

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,10 @@
 
 This file records changes to the codebase grouped by version release. Unreleased changes are generally only present during development (relevant parts of the changelog can be written and saved in that section before a version number has been assigned)
 
+## [1.26.4] - 2023-08-25
+
+- Some numerical errors in `model.py` (particularly relating to errors/warnings in parameter functions) are now caught and printed with more informative error messages. 
+
 ## [1.26.3] - 2023-07-18
 
 - Change the table parsing routine again to resolve further edge cases, restore removal of leading and trailing spaces from cells in the framework, and improve performance. The original `None` behaviour has consequently been restored (undoing the change in 1.26.2) although it is still recommended that `pandas.isna()` is used instead of checking for `None`.

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,15 @@
 
 This file records changes to the codebase grouped by version release. Unreleased changes are generally only present during development (relevant parts of the changelog can be written and saved in that section before a version number has been assigned)
 
+## [1.26.5] - 2023-08-29
+
+- Transfer parameters no longer raise an error if specified in 'Duration' units
+- Transfer parameters in rate units are no longer limited to a maximum value of 1
+
+*Backwards-compatibility notes*
+
+- Transfers in rate units with a databook value greater than 1 were internally limited to a value of 1 previously. Models with such transfers will produce different results. This is expected to be uncommon, as most models have transfer parameters with values less than 1.
+
 ## [1.26.4] - 2023-08-25
 
 - Some numerical errors in `model.py` (particularly relating to errors/warnings in parameter functions) are now caught and printed with more informative error messages. 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,10 @@
 
 This file records changes to the codebase grouped by version release. Unreleased changes are generally only present during development (relevant parts of the changelog can be written and saved in that section before a version number has been assigned)
 
+## [1.26.6] - 2023-09-26
+
+- Improve error message if calibration file contains duplicate entries
+
 ## [1.26.5] - 2023-08-29
 
 - Transfer parameters no longer raise an error if specified in 'Duration' units

--- a/atomica/model.py
+++ b/atomica/model.py
@@ -2160,10 +2160,10 @@ class Model:
                         par.units = transfer_parameter.ts[pop_target].units.strip().split()[0].strip().lower()
 
                         # Sampling might result in the parameter value going out of bounds, so make sure the transfer parameter values are constrained
-                        if par.units == FS.QUANTITY_TYPE_RATE or par.units == FS.QUANTITY_TYPE_PROBABILITY:
-                            par.limits = [0, 1]
-                        elif par.units == FS.QUANTITY_TYPE_NUMBER:
+                        if par.units in {FS.QUANTITY_TYPE_RATE,FS.QUANTITY_TYPE_PROBABILITY, FS.QUANTITY_TYPE_NUMBER}:
                             par.limits = [0, np.inf]
+                        elif par.units == FS.QUANTITY_TYPE_DURATION:
+                            par.limits = [model_settings["tolerance"], np.inf]
                         else:
                             raise Exception("Unknown transfer parameter units")
                         par.constrain()

--- a/atomica/parameters.py
+++ b/atomica/parameters.py
@@ -382,6 +382,12 @@ class ParameterSet(NamedItem):
         df = spreadsheet.pandas().parse()
         df.set_index(["par", "pop"], inplace=True)
 
+        if df.index.duplicated().any():
+            msg = f'The calibration file contained duplicate entries:'
+            for par, pop in df.index[df.index.duplicated()].unique():
+                msg += f'\n\t- {par} ({"meta/all populations" if pd.isna(pop) else pop})'
+            raise Exception(msg)
+
         for (par_name, pop_name), values in df.to_dict(orient="index").items():
 
             try:

--- a/atomica/version.py
+++ b/atomica/version.py
@@ -6,6 +6,6 @@ Standard location for module version number and date.
 
 import sciris as sc
 
-version = "1.26.5"
-versiondate = "2023-08-29"
+version = "1.26.6"
+versiondate = "2023-09-26"
 gitinfo = sc.gitinfo(__file__)

--- a/atomica/version.py
+++ b/atomica/version.py
@@ -6,6 +6,6 @@ Standard location for module version number and date.
 
 import sciris as sc
 
-version = "1.26.4"
-versiondate = "2023-08-25"
+version = "1.26.5"
+versiondate = "2023-08-29"
 gitinfo = sc.gitinfo(__file__)

--- a/atomica/version.py
+++ b/atomica/version.py
@@ -6,6 +6,6 @@ Standard location for module version number and date.
 
 import sciris as sc
 
-version = "1.26.3"
-versiondate = "2023-07-18"
+version = "1.26.4"
+versiondate = "2023-08-25"
 gitinfo = sc.gitinfo(__file__)

--- a/docs/conf.py
+++ b/docs/conf.py
@@ -55,6 +55,7 @@ extensions = [
     "nbsphinx",
     "sphinx.ext.intersphinx",  # Link to other project's documentation (see mapping below)
     "IPython.sphinxext.ipython_console_highlighting",  # Temporary fix for https://github.com/spatialaudio/nbsphinx/issues/687
+    "sphinxcontrib.jquery",  # Fix for https://github.com/readthedocs/sphinx_rtd_theme/issues/1452
 ]
 
 # Configure intersphinx


### PR DESCRIPTION
- Improve error message if calibration file contains duplicate entries
- Transfer parameters no longer raise an error if specified in 'Duration' units
- Transfer parameters in rate units are no longer limited to a maximum value of 1
- Some numerical errors in `model.py` (particularly relating to errors/warnings in parameter functions) are now caught and printed with more informative error messages. 