### PR TITLE
Timed compartment initialization

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,11 @@
 
 This file records changes to the codebase grouped by version release. Unreleased changes are generally only present during development (relevant parts of the changelog can be written and saved in that section before a version number has been assigned)
 
+## [1.28.3] - 2023-04-19
+
+- Added an option to save initial compartment sizes inside a `ParameterSet`. Importantly, this saved representation allows setting the initial _subcompartment_ sizes for a `TimedCompartment`. It therefore offers the possibility of initializing the model in a steady state computed from a previous simulation run, that would not be possible to initialize conventionally because standard initialization uniformly distributes people into the subcompartments of a timed compartment.  
+
+
 ## [1.28.2] - 2023-04-05
 
 - `at.calibrate` now supports passing any additional arguments into the optimization function e.g., `sc.asd` allowing additional options for customizing the optimization. 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,7 @@ This file records changes to the codebase grouped by version release. Unreleased
 ## [1.28.4] - 2023-05-27
 
 - Added an option to save initial compartment sizes inside a `ParameterSet`. Importantly, this saved representation allows setting the initial _subcompartment_ sizes for a `TimedCompartment`. It therefore offers the possibility of initializing the model in a steady state computed from a previous simulation run, that would not be possible to initialize conventionally because standard initialization uniformly distributes people into the subcompartments of a timed compartment.  
+- Added `ParameterSet.make_constant` to facilitate constructing copies of `ParameterSet` instances that are constant over time.
 
 ## [1.28.3] - 2023-05-16
 

--- a/atomica/excel.py
+++ b/atomica/excel.py
@@ -277,6 +277,9 @@ def read_dataframes(worksheet, merge=False) -> list:
 
     """
 
+    if worksheet.max_row is None or worksheet.max_column is None:
+        worksheet.calculate_dimension(force=True)
+
     content = np.empty((worksheet.max_row, worksheet.max_column), dtype="object")
     ignore = np.zeros((worksheet.max_row), dtype=bool)
     empty = np.zeros((worksheet.max_row), dtype=bool)  # True for index where a new table begins

--- a/atomica/framework.py
+++ b/atomica/framework.py
@@ -990,6 +990,8 @@ class ProjectFramework:
             elif par["format"] == FS.QUANTITY_TYPE_PROPORTION:
                 # Proportion units should never have a timescale since they are time-invariant
                 raise InvalidFramework("Parameter %s is in proportion units, therefore it cannot have a timescale entered for it" % par_name)
+            elif par["timescale"] <= 0:
+                raise InvalidFramework(f"Parameter {par_name} is specified in the framework as having a timescale of {par['timescale']}, which is not valid as timescales must be >0")
 
             if par["timed"] == "y":
                 if par["format"] != FS.QUANTITY_TYPE_DURATION:

--- a/atomica/migration.py
+++ b/atomica/migration.py
@@ -806,3 +806,10 @@ def _convert_framework_columns(framework):
 
     framework._validate()
     return framework
+
+@migration("ParameterSet", "1.28.2", "1.28.3", "Add initialization atttribute")
+def _parset_add_initialization(parset):
+    parset.initialization = None
+    return parset
+
+

--- a/atomica/model.py
+++ b/atomica/model.py
@@ -1848,6 +1848,16 @@ class Population:
 
         """
 
+
+        if not self.comps:
+            # If this population has no compartments, then nothing needs to be done
+            return
+
+        if parset.initialization is not None:
+            # If the parset contains explicit parameter values, try to apply them
+            parset.apply_initialization(self, framework)
+            return
+
         # Given a set of characteristics and their initial values, compute the initial
         # values for the compartments by solving the set of characteristics simultaneously
 

--- a/atomica/parameters.py
+++ b/atomica/parameters.py
@@ -288,7 +288,7 @@ class Initialization:
         if self.init_y_factor_hash is not None and framework is not None and parset is not None:
             init_y_factor_hash = self._hash_y_factors(framework, parset)
             if init_y_factor_hash != self.init_y_factor_hash:
-                logger.warning("Y-factors used for initialization have changed since the saved initialization was generated. These Y-factors will have no effect because a saved initialization is being used")
+                logger.warning("Y-factors used for initialization have changed since the saved initialization was generated. These Y-factors will have no effect because a saved initialization is being used. Remove the initialization by setting `Parset.initialization=None` to return to using the Y-factors to adjust the initialization.")
 
         for comp in pop.comps:
             if isinstance(comp, TimedCompartment):

--- a/atomica/parameters.py
+++ b/atomica/parameters.py
@@ -524,6 +524,24 @@ class ParameterSet(NamedItem):
             par.sample(constant)
         return new
 
+    def make_constant(self, year: float):
+        """
+        Return a constant copy of the ParameterSet
+
+        This function will return a copy of the ParameterSet where all parameter time series have been replaced
+        with temporally static versions.
+
+        :param year: Year to use for interpolation
+        :return: A copy of the ParameterSet with constant parameters
+        """
+        ps = self.copy(f'{self.name} (constant)')
+        for par in ps.all_pars():
+            for ts in par.ts.values():
+                ts.insert(None, ts.interpolate(year))
+                ts.t = []
+                ts.vals = []
+        return ps
+
     # SAVE AND LOAD CALIBRATION (Y-FACTORS)
 
     @property

--- a/atomica/parameters.py
+++ b/atomica/parameters.py
@@ -21,6 +21,7 @@ from .system import logger
 import itertools
 import json
 import hashlib
+from .version import version, gitinfo
 
 __all__ = ["Parameter", "ParameterSet"]
 
@@ -375,6 +376,8 @@ class ParameterSet(NamedItem):
 
     def __init__(self, framework, data, name="default"):
         NamedItem.__init__(self, name)
+        self.version = version  # Track versioning information
+        self.gitinfo = gitinfo
 
         self.pop_names = data.pops.keys()  # : List of all population code names contained in the ``ParameterSet``
         self.pop_labels = [pop["label"] for pop in data.pops.values()]  # : List of corresponding full names for populations
@@ -451,6 +454,13 @@ class ParameterSet(NamedItem):
 
             for source_pop, ts in ts_dict.items():
                 item_storage[name][source_pop] = Parameter(name + "_from_" + source_pop, sc.dcp(ts))
+
+    def __setstate__(self, d):
+        from .migration import migrate
+
+        self.__dict__ = d
+        parset = migrate(self)
+        self.__dict__ = parset.__dict__
 
     def all_pars(self):
         """

--- a/atomica/parameters.py
+++ b/atomica/parameters.py
@@ -182,7 +182,7 @@ class Initialization:
     as capturing metadata for validation purposes.
     """
 
-    def __init__(self, values=None):
+    def __init__(self, values=None, year=None, init_y_factor_hash=None, dt=None):
         """
         Construct an Initialization with explicit initial values
 
@@ -199,10 +199,13 @@ class Initialization:
                        compartments are being used, the ``Initialization`` instance will not be reusable if the
                        simulation step size is subsequently changed, and will need to be re-created using the new
                        step size).
+        :param year: Optionally specify the year used to generate the initialization (for provenance)
+        :param init_y_factor_hash: Optionally specify the y-factor hash. If supplied, this will be checked against the parset when the initialization is applied
+        :param dt: Optionally specify the timestep used to generate the initialization (for provenance)
         """
-        self.year = None
-        self.init_y_factor_hash = None
-        self.dt = None
+        self.year = year
+        self.init_y_factor_hash = init_y_factor_hash
+        self.dt = dt
         self.values = values
 
     @classmethod

--- a/atomica/parameters.py
+++ b/atomica/parameters.py
@@ -245,11 +245,12 @@ class Initialization:
 
         self = cls(values)
         self.year = year  #: Record year from which the initialization was originally computed
-        self.init_y_factor_hash = None if parset is None else self._hash_y_factors(res.model.framework, parset)  # Record a hash of the Y-factors used for initialization
+        self.init_y_factor_hash = None if parset is None else self.hash_y_factors(res.model.framework, parset)  # Record a hash of the Y-factors used for initialization
         self.dt = res.dt
         return self
 
-    def _hash_y_factors(self, framework, parset) -> str:
+    @staticmethod
+    def hash_y_factors(framework, parset) -> str:
         """
         Hash y-factors used for initialization
 
@@ -289,7 +290,7 @@ class Initialization:
 
         # Check the y-factors
         if self.init_y_factor_hash is not None and framework is not None and parset is not None:
-            init_y_factor_hash = self._hash_y_factors(framework, parset)
+            init_y_factor_hash = self.hash_y_factors(framework, parset)
             if init_y_factor_hash != self.init_y_factor_hash:
                 logger.warning("Y-factors used for initialization have changed since the saved initialization was generated. These Y-factors will have no effect because a saved initialization is being used. Remove the initialization by setting `Parset.initialization=None` to return to using the Y-factors to adjust the initialization.")
 

--- a/atomica/programs.py
+++ b/atomica/programs.py
@@ -162,7 +162,7 @@ class ProgramSet(NamedItem):
         assert data is not None, "Must specify framework and data when instantiating a ProgramSet"
 
         NamedItem.__init__(self, name)
-        self.version = version  # Track versioning information for the result. This might change due to migration (whereas by convention, the model version does not)
+        self.version = version  # Track versioning information
         self.gitinfo = gitinfo
 
         self.tvec = tvec  # This is the data tvec that will be used when writing the progset to a spreadsheet

--- a/atomica/version.py
+++ b/atomica/version.py
@@ -6,6 +6,6 @@ Standard location for module version number and date.
 
 import sciris as sc
 
-version = "1.28.2"
-versiondate = "2024-04-05"
+version = "1.28.3"
+versiondate = "2024-04-19"
 gitinfo = sc.gitinfo(__file__)

--- a/tests/text_tox_timed_initialization.py
+++ b/tests/text_tox_timed_initialization.py
@@ -26,33 +26,19 @@ def test_timed_initialization():
     D.tdve["tx_rate"].ts[0].insert(2021, 0)
     D.tdve["tx_rate"].ts[0].insert(2022, 0.5)
 
-
-    def make_constant_parset(F, D, year):
-        D2 = sc.dcp(D)
-        for table in D2.tables():
-            for ts in table.ts.values():
-                ts.insert(None, ts.interpolate(year))
-                ts.t = []
-                ts.vals = []
-        return at.ParameterSet(F, D2, "constant")
-
-
     def set_initialization_basic(F, D, year, y_factor=True):
-        # ps1 = make_constant_parset(F, D, year)
-        res = P.run_sim(make_constant_parset(F, D, 2018))
-
+        # Conventional approach using Y-factor adjustment only
+        res = P.run_sim(P.parsets[0].make_constant(2018))
         ps2 = at.ParameterSet(F, D, "basic")
 
         # Set initial compartment sizes for initialization quantities
         for qty in itertools.chain(F.characs.index[F.characs['setup weight'] > 0], F.comps.index[F.comps['setup weight'] > 0]):
             for pop in D.pops:
-
                 if y_factor:
                     ps2.pars[qty].meta_y_factor = 1
                     ps2.pars[qty].y_factor[pop] = res.get_variable(qty, pop)[0].vals[-1]/ps2.pars[qty].ts[pop].interpolate(year)
                 else:
                     ps2.pars[qty].ts[pop].insert(year, res.get_variable(qty, pop)[0].vals[-1])
-
 
         return ps2
 

--- a/tests/text_tox_timed_initialization.py
+++ b/tests/text_tox_timed_initialization.py
@@ -18,70 +18,72 @@ import itertools
 testdir = at.parent_dir()
 tmpdir = testdir / "temp"
 
+def test_timed_initialization():
 
-F = at.ProjectFramework(testdir / "timed_initialization_test_framework.xlsx")
-D = at.ProjectData.new(F, [2018], 1, 0)
-D.tdve["tx_rate"].ts[0].insert(2018, 0)
-D.tdve["tx_rate"].ts[0].insert(2021, 0)
-D.tdve["tx_rate"].ts[0].insert(2022, 0.5)
-
-
-def make_constant_parset(F, D, year):
-    D2 = sc.dcp(D)
-    for table in D2.tables():
-        for ts in table.ts.values():
-            ts.insert(None, ts.interpolate(year))
-            ts.t = []
-            ts.vals = []
-    return at.ParameterSet(F, D2, "constant")
+    F = at.ProjectFramework(testdir / "timed_initialization_test_framework.xlsx")
+    D = at.ProjectData.new(F, [2018], 1, 0)
+    D.tdve["tx_rate"].ts[0].insert(2018, 0)
+    D.tdve["tx_rate"].ts[0].insert(2021, 0)
+    D.tdve["tx_rate"].ts[0].insert(2022, 0.5)
 
 
-def set_initialization_basic(F, D, year, y_factor=True):
-    # ps1 = make_constant_parset(F, D, year)
-    res = P.run_sim(make_constant_parset(F, D, 2018))
-
-    ps2 = at.ParameterSet(F, D, "basic")
-
-    # Set initial compartment sizes for initialization quantities
-    for qty in itertools.chain(F.characs.index[F.characs['setup weight'] > 0], F.comps.index[F.comps['setup weight'] > 0]):
-        for pop in D.pops:
-
-            if y_factor:
-                ps2.pars[qty].meta_y_factor = 1
-                ps2.pars[qty].y_factor[pop] = res.get_variable(qty, pop)[0].vals[-1]/ps2.pars[qty].ts[pop].interpolate(year)
-            else:
-                ps2.pars[qty].ts[pop].insert(year, res.get_variable(qty, pop)[0].vals[-1])
+    def make_constant_parset(F, D, year):
+        D2 = sc.dcp(D)
+        for table in D2.tables():
+            for ts in table.ts.values():
+                ts.insert(None, ts.interpolate(year))
+                ts.t = []
+                ts.vals = []
+        return at.ParameterSet(F, D2, "constant")
 
 
-    return ps2
+    def set_initialization_basic(F, D, year, y_factor=True):
+        # ps1 = make_constant_parset(F, D, year)
+        res = P.run_sim(make_constant_parset(F, D, 2018))
+
+        ps2 = at.ParameterSet(F, D, "basic")
+
+        # Set initial compartment sizes for initialization quantities
+        for qty in itertools.chain(F.characs.index[F.characs['setup weight'] > 0], F.comps.index[F.comps['setup weight'] > 0]):
+            for pop in D.pops:
+
+                if y_factor:
+                    ps2.pars[qty].meta_y_factor = 1
+                    ps2.pars[qty].y_factor[pop] = res.get_variable(qty, pop)[0].vals[-1]/ps2.pars[qty].ts[pop].interpolate(year)
+                else:
+                    ps2.pars[qty].ts[pop].insert(year, res.get_variable(qty, pop)[0].vals[-1])
 
 
-P = at.Project(framework=F, databook=D, do_run=False)
-P.settings.sim_dt = 1 / 12
-P.settings.sim_start = 2018
-P.settings.sim_end = 2023
-
-res1 = P.run_sim()
-
-# Basic steady state initialization
-ps = set_initialization_basic(F, D, 2018)
-res2 = P.run_sim(ps, result_name='basic')
-
-# Advanced steady state initialization
-ps2 = at.ParameterSet(F,D)
-ps2.set_initialization(res1, 2021)
-res3 = P.run_sim(ps2, result_name='advanced')
-
-ps2.pars['alive'].y_factor[0] = 1.1
-
-ps2.save_calibration(tmpdir/'test_cal.xlsx')
-res3 = P.run_sim(ps2, result_name='advanced')
-
-ps4 = P.make_parset('saved')
-ps4.load_calibration(tmpdir/'test_cal.xlsx')
-res4 = P.run_sim(ps4, result_name='loaded')
+        return ps2
 
 
+    P = at.Project(framework=F, databook=D, do_run=False)
+    P.settings.sim_dt = 1 / 12
+    P.settings.sim_start = 2018
+    P.settings.sim_end = 2023
 
-d = at.PlotData([res1, res2, res3, res4], ["sus", "inf", "rec"])
-at.plot_series(d)
+    res1 = P.run_sim()
+
+    # Basic steady state initialization
+    ps = set_initialization_basic(F, D, 2018)
+    res2 = P.run_sim(ps, result_name='basic')
+
+    # Advanced steady state initialization
+    ps2 = at.ParameterSet(F,D)
+    ps2.set_initialization(res1, 2021)
+    res3 = P.run_sim(ps2, result_name='advanced')
+
+    ps2.pars['alive'].y_factor[0] = 1.1
+
+    ps2.save_calibration(tmpdir/'test_cal.xlsx')
+    res3 = P.run_sim(ps2, result_name='advanced')
+
+    ps4 = P.make_parset('saved')
+    ps4.load_calibration(tmpdir/'test_cal.xlsx')
+    res4 = P.run_sim(ps4, result_name='loaded')
+
+    d = at.PlotData([res1, res2, res3, res4], ["sus", "inf", "rec"])
+    at.plot_series(d)
+
+if __name__ == '__main__':
+    test_timed_initialization()

--- a/tests/text_tox_timed_initialization.py
+++ b/tests/text_tox_timed_initialization.py
@@ -1,0 +1,79 @@
+import atomica as at
+import sciris as sc
+import os
+import pytest
+import sys
+import itertools
+
+# # P = at.Project(framework='dummy_framework.xlsx',databook='dummy_databook.xlsx')
+# # # P.run_sim()
+# # P = at.demo('tb',do_run=True)
+# # P.results[0].plot()
+# # P = at.Project.load('asdf2.prj')
+#
+# # P = at.Project(framework=at.LIBRARY_PATH+'tb_framework.xlsx')
+# # P.load_databook(at.LIBRARY_PATH+'tb_databook.xlsx')
+# P = at.demo('tb',do_run=True)
+
+testdir = at.parent_dir()
+tmpdir = testdir / "temp"
+
+
+F = at.ProjectFramework(testdir / "timed_initialization_test_framework.xlsx")
+D = at.ProjectData.new(F, [2018], 1, 0)
+D.tdve["tx_rate"].ts[0].insert(2018, 0)
+D.tdve["tx_rate"].ts[0].insert(2021, 0)
+D.tdve["tx_rate"].ts[0].insert(2022, 0.5)
+
+
+def make_constant_parset(F, D, year):
+    D2 = sc.dcp(D)
+    for table in D2.tables():
+        for ts in table.ts.values():
+            ts.insert(None, ts.interpolate(year))
+            ts.t = []
+            ts.vals = []
+    return at.ParameterSet(F, D2, "constant")
+
+
+def set_initialization_basic(F, D, year, y_factor=True):
+    # ps1 = make_constant_parset(F, D, year)
+    res = P.run_sim(make_constant_parset(F, D, 2018))
+
+    ps2 = at.ParameterSet(F, D, "basic")
+
+    # Set initial compartment sizes for initialization quantities
+    for qty in itertools.chain(F.characs.index[F.characs['setup weight'] > 0], F.comps.index[F.comps['setup weight'] > 0]):
+        for pop in D.pops:
+
+            if y_factor:
+                ps2.pars[qty].meta_y_factor = 1
+                ps2.pars[qty].y_factor[pop] = res.get_variable(qty, pop)[0].vals[-1]/ps2.pars[qty].ts[pop].interpolate(year)
+            else:
+                ps2.pars[qty].ts[pop].insert(year, res.get_variable(qty, pop)[0].vals[-1])
+
+
+    return ps2
+
+
+P = at.Project(framework=F, databook=D, do_run=False)
+P.settings.sim_dt = 1 / 12
+P.settings.sim_start = 2018
+P.settings.sim_end = 2023
+
+res1 = P.run_sim()
+
+# Basic steady state initialization
+ps = set_initialization_basic(F, D, 2018)
+res2 = P.run_sim(ps, result_name='basic')
+
+# Advanced steady state initialization
+ps2 = at.ParameterSet(F,D)
+ps2.set_initialization(res1, 2021)
+res3 = P.run_sim(ps2, result_name='advanced')
+
+ps2.pars['alive'].y_factor[0] = 1.1
+res3 = P.run_sim(ps2, result_name='advanced')
+
+d = at.PlotData([res1, res2, res3], ["sus", "inf", "rec"])
+at.plot_series(d)

--- a/tests/text_tox_timed_initialization.py
+++ b/tests/text_tox_timed_initialization.py
@@ -73,7 +73,15 @@ ps2.set_initialization(res1, 2021)
 res3 = P.run_sim(ps2, result_name='advanced')
 
 ps2.pars['alive'].y_factor[0] = 1.1
+
+ps2.save_calibration(tmpdir/'test_cal.xlsx')
 res3 = P.run_sim(ps2, result_name='advanced')
 
-d = at.PlotData([res1, res2, res3], ["sus", "inf", "rec"])
+ps4 = P.make_parset('saved')
+ps4.load_calibration(tmpdir/'test_cal.xlsx')
+res4 = P.run_sim(ps4, result_name='loaded')
+
+
+
+d = at.PlotData([res1, res2, res3, res4], ["sus", "inf", "rec"])
 at.plot_series(d)


### PR DESCRIPTION
This PR implements a feature we discussed a while ago - saving initial compartment sizes *including subcompartment sizes for timed compartments* into a `ParameterSet` where they are considered to be part of the calibration. This means that it's possible to actually initialize the model in a steady state respecting the steady state values of the subcompartment. For example

Default initialization

![image](https://github.com/atomicateam/atomica/assets/755796/0070b69f-6ff6-4294-8e77-eb05ce4874c2)

Setting the correct steady state compartment sizes in the databook/via Y-factors (but without setting subcompartment values)

![image](https://github.com/atomicateam/atomica/assets/755796/2df2cd74-b53a-49fe-ba2e-b9c314718abe)

Even though the total steady state values are correct, there is still a small transient because the subcompartments are not at equilibrium. With the new functionality

![image](https://github.com/atomicateam/atomica/assets/755796/c67ee7e7-5191-4066-8c2e-dc588a83788d)

The transients at the start are now gone. The main functionality is

```
res = P.run_sim(result_name='basic')
ps = P.make_parset()
ps.set_initialization(res, 2021)
```

Where in this example, a simulation is first run, a new parset is created, and then the compartment sizes from the simulation at t=2021 are saved into the parset. When the parset is saved e.g., with `ps.save_calibration('test.xlsx')` then the spreadsheet contains a new extra sheet for the initialization

![image](https://github.com/atomicateam/atomica/assets/755796/a6f86a62-d694-4f73-8133-11bb9d18f570)

Where here, the array of values on row 7 corresponds to the subcompartment values. Normally users would not be expected to interact with this sheet directly. The y-factor hash is used to display a warning to users if the initialization y-factors have been changed, because if an initialization is present in the parset, the initialization y-factors will have no effect (because the explicit initial compartment sizes are the ones that get used for the initialization). 

Some key aspects are

- If the initialization y-factors have been changed (and the initialization was saved with a y-factor hash, and if the framework and parset are also provided when applying the initialization - all of these are done automatically if the user saves the initialization with `Parset.set_initialization` but might not happen if the user is doing things more manually for whatever reason) a warning will be given but the model will still run. This is because the initialization y-factors have no effect if the initialization is explicitly specified, so we want to warn the user that they need to drop the initialization if they want to adjust the y-factors (but we don't raise an error because the model can still be run)
- If other y-factors have been changed, the model's steady state might be different, but no warning or error will occur
- If the simulation time step or duration parameters are otherwise changed, then the number of time points in the initialization could be different. An array size error will occur in that case
- If there are missing compartments in the initialization (because they have been subsequently added to the framework) they will be initialized with a value of 0. This is slightly different to what might happen with the Y-factor initialization, if people are uniformly distributed across a group of compartments, adding a compartment to the group would see the new compartment initialized with a nonzero number of people

This is hopefully all in line with what we discussed a while ago, keen for feedback and thoughts on whether this addresses all of the use cases and if the interface is suitable

