### PR TITLE
Project init

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,10 @@
 
 This file records changes to the codebase grouped by version release. Unreleased changes are generally only present during development (relevant parts of the changelog can be written and saved in that section before a version number has been assigned)
 
+## [1.28.3] - 2023-05-16
+
+- Updated `at.Project()` to explicitly take in the settings arguments for `sim_start`, `sim_end`, and `sim_dt`. These are now applied after databooks are loaded, fixing a bug where these arguments would get overwritten when loading the databook.
+
 ## [1.28.2] - 2023-04-05
 
 - `at.calibrate` now supports passing any additional arguments into the optimization function e.g., `sc.asd` allowing additional options for customizing the optimization. 

--- a/atomica/plotting.py
+++ b/atomica/plotting.py
@@ -1813,7 +1813,12 @@ def reorder_legend(figs, order=None) -> None:
     if order is None:
         return
     elif order == "reverse":
-        order = range(len(legend.legendHandles) - 1, -1, -1)
+        try:
+            # matplotlib<3.8
+            order = range(len(legend.legendHandles) - 1, -1, -1)
+        except AttributeError:
+            # matplotlib>=3.9
+            order = range(len(legend.legend_handles) - 1, -1, -1)
     else:
         assert max(order) < len(vpacker._children), "Requested index greater than number of legend entries"
 

--- a/atomica/version.py
+++ b/atomica/version.py
@@ -6,6 +6,6 @@ Standard location for module version number and date.
 
 import sciris as sc
 
-version = "1.28.2"
-versiondate = "2024-04-05"
+version = "1.28.3"
+versiondate = "2024-05-16"
 gitinfo = sc.gitinfo(__file__)

--- a/tests/test_tox_timed_compartments.py
+++ b/tests/test_tox_timed_compartments.py
@@ -73,7 +73,7 @@ def test_timed_tb():
     # Just check that it runs as a demonstration
     P = at.Project(framework=testdir / "timed_tb_framework.xlsx", databook=testdir / "timed_tb_databook.xlsx", do_run=False)
     P.settings.sim_dt = 0.25
-    return P.run_sim()
+    P.run_sim()
 
 
 def test_spike():


### PR DESCRIPTION
Fixes a minor bug in project creation where arguments like `sim_start` would be ignored because they were being applied before loading a databook rather than after