### PR TITLE
Skip start of optimization until the first measurable or adjustable

### DIFF
--- a/atomica/optimization.py
+++ b/atomica/optimization.py
@@ -17,7 +17,7 @@ import scipy.optimize
 
 import sciris as sc
 from .cascade import get_cascade_vals
-from .model import Model, Link
+from .model import Model, Link, run_model
 from .parameters import ParameterSet
 from .programs import ProgramSet, ProgramInstructions
 from .results import Result
@@ -1364,7 +1364,58 @@ def _objective_fcn(x, pickled_model, optimization, hard_constraints: list, basel
     return obj_val
 
 
-def optimize(project, optimization, parset: ParameterSet, progset: ProgramSet, instructions: ProgramInstructions, x0=None, xmin=None, xmax=None, hard_constraints=None, baselines=None, optim_args: dict = None):
+def _calc_skippable_year(optimization):
+    skip_start_year = False
+
+    allowed_adjustments = (SpendingAdjustment, )
+    allowed_measurables = (MinimizeMeasurable, MaximizeMeasurable, AtMostMeasurable, AtLeastMeasurable, IncreaseByMeasurable, DecreaseByMeasurable, MaximizeCascadeStage, MaximizeCascadeConversionRate)
+    # type not isinstance because subclasses might have different behaviour
+    if all(type(adjustment) in allowed_adjustments for adjustment in optimization.adjustments) and all(type(measurable) in allowed_measurables for measurable in optimization.measurables):
+        skip_start_year_adj  = min(min(sc.promotetoarray(spending_adjustment.t)) for spending_adjustment in optimization.adjustments)
+        skip_start_year_meas = min(min(sc.promotetoarray(measurable.t))          for measurable in optimization.measurables)
+        skip_start_year = min((skip_start_year_adj, skip_start_year_meas))
+
+        if not np.isfinite(skip_start_year):
+            skip_start_year = False
+
+    return skip_start_year
+
+
+def _make_skip_model(optimization, project, parset, progset, instructions, skip_start):
+    if skip_start == False:
+        return None
+
+    possible_skip_year = _calc_skippable_year(optimization)
+
+    if skip_start is None:
+        if not possible_skip_year:
+            return None
+        skip_start = possible_skip_year
+
+    if type(skip_start) == bool: # skip_start == True
+        if not possible_skip_year:
+            raise Exception('skip_start == True, but do not know which year it is possible to skip until, please set skip_start = year you want to skip to')
+        skip_start = possible_skip_year
+
+    # skip_start is now a float or int hopefully
+    assert float(skip_start) > project.settings.sim_start, f'skip_start ({skip_start}) should be a number larger than the original starting year ({project.settings.sim_start})'
+    skip_start = float(skip_start)
+
+    if skip_start > possible_skip_year:
+        logger.warning(f"skip_start was set to {skip_start} but the calculated safe year to start at is {possible_skip_year} - so the optimization might not give accurate results")
+
+    logger.info(f"Skipping until year {skip_start}")
+
+    tmp_settings, tmp_parset = sc.dcp(project.settings), sc.dcp(parset)
+
+    res = run_model(settings=tmp_settings, framework=project.framework, parset=tmp_parset, progset=progset, program_instructions=instructions)
+    tmp_parset.set_initialization(res, year=skip_start)
+    tmp_settings.update_time_vector(start=skip_start)
+
+    model = Model(tmp_settings, project.framework, tmp_parset, progset, instructions)
+    return model
+
+def optimize(project, optimization, parset: ParameterSet, progset: ProgramSet, instructions: ProgramInstructions, x0=None, xmin=None, xmax=None, hard_constraints=None, baselines=None, optim_args: dict = None, skip_start=None):
     """
     Main user entry point for optimization
 
@@ -1386,13 +1437,19 @@ def optimize(project, optimization, parset: ParameterSet, progset: ProgramSet, i
     :param hard_constraints: Not for manual use - override hard constraints
     :param baselines: Not for manual use - override Measurable baseline values (for relative Measurables)
     :param optim_args: Pass a dictionary of keyword arguments to pass to the optimization algorithm (set in ``optimization.method``)
+    :param skip_start: True or False or a year to start the optimization runs at (everything before that year will be kept the same)
     :return: A :class:`ProgramInstructions` instance representing optimal instructions
 
     """
 
     assert optimization.method in ["asd", "pso", "hyperopt"]
 
-    model = Model(project.settings, project.framework, parset, progset, instructions)
+    model = None
+    if skip_start is None or skip_start:
+        model = _make_skip_model(optimization, project, parset, progset, instructions, skip_start)
+    if model is None:
+        model = Model(project.settings, project.framework, parset, progset, instructions)
+
     pickled_model = pickle.dumps(model)  # Unpickling effectively makes a deep copy, so this _should_ be faster
 
     initialization = optimization.get_initialization(progset, model.program_instructions)

--- a/atomica/optimization.py
+++ b/atomica/optimization.py
@@ -1074,7 +1074,7 @@ class TotalSpendConstraint(Constraint):
             x0 = sc.odict()  # Order matters here
             lb = []
             ub = []
-            progs = hard_constraints["programs"][t]  # Programs eligible for constraining at this time
+            progs = sorted(hard_constraints["programs"][t])  # Programs eligible for constraining at this time
 
             for prog in progs:
                 if prog not in instructions.alloc:

--- a/atomica/optimization.py
+++ b/atomica/optimization.py
@@ -1526,6 +1526,12 @@ def constrain_sum_bounded(x: np.array, s: float, lb: np.array, ub: np.array) -> 
     """
     tolerance = 1e-6
 
+    sort_inds = np.argsort(x)
+    orig_inds = np.argsort(sort_inds)
+    x  = np.array(x) [sort_inds]
+    lb = np.array(lb)[sort_inds]
+    ub = np.array(ub)[sort_inds]
+
     # Normalize values
     x0_scaled = x / (x.sum() or 1)  # Normalize the initial values, unless they sum to 0 (i.e., they are all zero)
     lb_scaled = lb / s
@@ -1534,7 +1540,7 @@ def constrain_sum_bounded(x: np.array, s: float, lb: np.array, ub: np.array) -> 
     # First, check if the constraint is already satisfied just by multiplicative rescaling
     # The final check for x0_scaled.sum()==1 catches the case where all of the input values are 0
     if np.all((x0_scaled >= lb_scaled) & (x0_scaled <= ub_scaled)) and np.isclose(x0_scaled.sum(), 1):
-        return x0_scaled * s
+        return x0_scaled[orig_inds] * s
 
     # If not, we need to actually run the constrained optimization
     bounds = [(lower, upper) for lower, upper in zip(lb_scaled, ub_scaled)]
@@ -1557,4 +1563,6 @@ def constrain_sum_bounded(x: np.array, s: float, lb: np.array, ub: np.array) -> 
     # Enforce upper/lower bound constraints to prevent numerically exceeding them
     sol = np.minimum(np.maximum(res["x"], lb_scaled), ub_scaled) * s
     assert np.isclose(sol.sum(), s), f"FAILED as {sol} has a total of {sol.sum()} which is not sufficiently close to the target value {s}"
+
+    sol = sol[orig_inds]
     return sol


### PR DESCRIPTION
Possibly could skip until the first adjustment, as the measurables will all be the same before any adjustable changes anything? 

Haven't yet checked for:
 - [ ] derivative parameters

Might revert https://github.com/atomicateam/atomica/commit/8b790803d9c48a6d7c01dd7905f5f37aa4270cca as discussed in https://github.com/atomicateam/atomica/issues/504

Feel free to re-factor @RomeshA 