### PR TITLE
Total pop calibration

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,11 @@
 
 This file records changes to the codebase grouped by version release. Unreleased changes are generally only present during development (relevant parts of the changelog can be written and saved in that section before a version number has been assigned)
 
+## [1.28.6] - 2023-07-12
+
+- Support entering `'total'` as the population name in auto-calibration measurables to calibrate aggregated values across populations in the model to aggregate values entered in the databook under a 'Total' population
+
+
 ## [1.28.5] - 2023-06-28
 
 - Enable automated calibration of transfers and updated documentation to cover this feature

--- a/atomica/calibration.py
+++ b/atomica/calibration.py
@@ -34,7 +34,7 @@ def _update_parset(parset, y_factors, pars_to_adjust):
         pop_name = x[1]
 
         if par_name in parset.pars:
-            if pop_name == "all":
+            if pop_name.lower() == "all":
                 par = parset.pars[par_name]
                 par.meta_y_factor = y_factors[i]
             else:
@@ -66,7 +66,8 @@ def _calculate_objective(y_factors, pars_to_adjust, output_quantities, parset, p
             continue
         if not target.has_time_data:  # Only use this output quantity if the user entered time-specific data
             continue
-        if pop_name == 'Total':
+
+        if pop_name.lower() == 'total':
             var = atomica.PlotData(result, outputs=var_label, pops = 'total', project=project)
         else:
             var = result.model.get_pop(pop_name).get_variable(var_label)
@@ -77,7 +78,7 @@ def _calculate_objective(y_factors, pars_to_adjust, output_quantities, parset, p
         # If there is data outside the range when the model was simulated, don't
         # extrapolate the model outputs
         y = data_v
-        if pop_name == 'Total':
+        if pop_name.lower() == 'total':
             y2 = np.interp(data_t, var.series[0].tvec, var.series[0].vals, left=np.nan, right=np.nan)
         else:
             y2 = np.interp(data_t, var[0].t, var[0].vals, left=np.nan, right=np.nan)
@@ -179,7 +180,7 @@ def calibrate(project, parset: ParameterSet, pars_to_adjust, output_quantities, 
         par_name, pop_name, scale_min, scale_max = x
         if par_name in parset.pars:
             par = parset.pars[par_name]
-            if pop_name == "all":
+            if pop_name.lower() == "all":
                 x0.append(par.meta_y_factor)
             else:
                 x0.append(par.y_factor[pop_name])
@@ -244,7 +245,7 @@ def calibrate(project, parset: ParameterSet, pars_to_adjust, output_quantities, 
         if par_name in parset.pars:
             par = args["parset"].pars[par_name]
 
-            if pop_name == "all":
+            if pop_name.lower() == "all":
                 logger.debug("parset.get_par('{}').meta_y_factor={:.2f}".format(par_name, par.meta_y_factor))
             else:
                 logger.debug("parset.get_par('{}').y_factor['{}']={:.2f}".format(par_name, pop_name, par.y_factor[pop_name]))

--- a/atomica/calibration.py
+++ b/atomica/calibration.py
@@ -136,7 +136,12 @@ def calibrate(project, parset: ParameterSet, pars_to_adjust, output_quantities, 
                            as the ``pop_name``. For example, to automatically calibrate an aging transfer 'age' from 5-14
                            to 15-64, the tuple would contain ``pars_to_adjust=[('age_from_5-14','15-64',...)]``
     :param output_quantities: list of tuples, (var_label,pop_name,weight,metric), for use in the objective
-                              function. pop_name=None will expand to all pops. pop_name='all' is not supported
+                              function. pop_name=None will expand to all pops. pop_name='all' is not supported. In some cases,
+                              it may be desirable to fit to an aggregated total value across populations. In such cases, the
+                              databook should have an extra row in the TDVE table for a population called "Total". The measurable
+                              can then be given pop_name="Total" which will cause the Atomica model outputs to be aggregated over
+                              all populations, and the aggregate value compared to the "Total" data. The aggregation methods will
+                              be automatically selected depending on units of the quantity (sum for "number" units, average for others).
     :param max_time: If using ASD, the maximum run time
     :param method: 'asd' or 'pso'. If using 'pso' all upper and lower limits must be finite
     :param kwargs: Dictionary of additional arguments to be passed to the optimization function, e.g. stepsize or pinitial

--- a/atomica/calibration.py
+++ b/atomica/calibration.py
@@ -78,7 +78,7 @@ def _calculate_objective(y_factors, pars_to_adjust, output_quantities, parset, p
         # extrapolate the model outputs
         y = data_v
         if pop_name == 'Total':
-            y2 = np.interp(data_t, var.tvals()[0], var.series[0].vals, left=np.nan, right=np.nan)
+            y2 = np.interp(data_t, var.series[0].tvec, var.series[0].vals, left=np.nan, right=np.nan)
         else:
             y2 = np.interp(data_t, var[0].t, var[0].vals, left=np.nan, right=np.nan)
 

--- a/atomica/version.py
+++ b/atomica/version.py
@@ -6,6 +6,6 @@ Standard location for module version number and date.
 
 import sciris as sc
 
-version = "1.28.5"
-versiondate = "2024-06-28"
+version = "1.28.6"
+versiondate = "2024-07-12"
 gitinfo = sc.gitinfo(__file__)


### PR DESCRIPTION
Edit the objective function calculation to allow the Measurables to use total population data ('Total'). 

The total population calculation is calculated using the `PlotData` function.

All four inputs (`measurable, target population, weight, metric`)
Example: 
 `cal = P.calibrate(max_time=100, parset=cal, adjustables=['infx'], measurables=[('chronic_total', 'Total', 1.0, 'fractional')])`