### PR TITLE
Time vector precision

### DIFF
--- a/atomica/project.py
+++ b/atomica/project.py
@@ -98,7 +98,7 @@ class ProjectSettings:
         # running a model over the range [2000,2066) with dt=1/12, it calculates 791.9999999999982 time steps
         # rather than 792, in that case we can convert to a float32 to effectively round it to 792 before
         # taking the integer. This should generally be safe for the types of values that get used for simulation years
-        return np.linspace(self.sim_start, self.sim_end, int(np.float32(((self.sim_end - self.sim_start) / self.sim_dt))) + 1)
+        return np.linspace(self.sim_start, self.sim_end, int(np.float32(((self.sim_end - self.sim_start) / self.sim_dt))) + 1, dtype='float32')
 
     def update_time_vector(self, start: float = None, end: float = None, dt: float = None) -> None:
         """

--- a/atomica/project.py
+++ b/atomica/project.py
@@ -88,17 +88,13 @@ class ProjectSettings:
         """
         Return simulation time vector
 
-        This method uses `linspace` rather than `arange` to avoid accumulating numerical errors that prevent
-        integer years aligning exactly.
+        This method uses `arange` with a step size of 1, then multiplies with the correct step size and add sim start time.
 
         :return: Array of simulation times
 
         """
-        # The int(np.float32()) helps cases where the numerical precision results in unwanted truncation e.g.,
-        # running a model over the range [2000,2066) with dt=1/12, it calculates 791.9999999999982 time steps
-        # rather than 792, in that case we can convert to a float32 to effectively round it to 792 before
-        # taking the integer. This should generally be safe for the types of values that get used for simulation years
-        return np.linspace(self.sim_start, self.sim_end, int(np.float32(((self.sim_end - self.sim_start) / self.sim_dt))) + 1, dtype='float32')
+
+        return np.arange(round((self.sim_end - self.sim_start) / self.sim_dt) + 1) * self.sim_dt + self.sim_start
 
     def update_time_vector(self, start: float = None, end: float = None, dt: float = None) -> None:
         """

--- a/tests/test_time_vector.py
+++ b/tests/test_time_vector.py
@@ -1,0 +1,33 @@
+# Test time vector
+# The problem:
+# In atomica, we want to include the end year: Say we're running a simulation from 2000 to 2050 ->
+# we want to be able to get the results for year 2000, 2001, ... and 2050. Hence, we need to run
+# more time steps after 2050
+
+# # On develop branch: Creates 611 entries -> if taken the integer,the last year doesn't have enough entries
+# On temporal weights: Creates 612 entries -> but 13 in 2038 and 11 in 2048
+
+import atomica as at
+import numpy as np
+
+
+def test_time_vector():
+    # Creating a setting object
+    analysis_years = (2000, 2050)
+    dt = 1 / 12
+    settings = at.ProjectSettings(sim_start=analysis_years[0], sim_end=analysis_years[1] + 1 - dt, sim_dt=dt)  #: Atomica project settings
+    tvec = settings.tvec  #: Simulation/result time points
+
+    assert len(set(np.unique(tvec.astype(int), return_counts=True)[1])) == 1
+    
+    # on temporal weights branch: np.linspace(self.sim_start, self.sim_end, int(np.float32(((self.sim_end - self.sim_start) / self.sim_dt))) + 1)
+    #  tvec = np.linspace(2000, 2051-1/12, int(np.float32(((2051-1/12 - 2000) / (1/12)))) + 1)
+
+    # on develop branch: np.linspace(self.sim_start, self.sim_end, int((self.sim_end - self.sim_start) / self.sim_dt) + 1)
+    # develop: tvec = np.linspace(2000, 2051-1/12, int((2051-1/12 - 2000) / (1/12)) + 1)
+    # np.unique(tvec.astype(int), return_counts=True)
+
+
+
+if __name__ == "__main__":
+    test_time_vector()

--- a/tests/test_time_vector.py
+++ b/tests/test_time_vector.py
@@ -2,31 +2,23 @@
 # The problem:
 # In atomica, we want to include the end year: Say we're running a simulation from 2000 to 2050 ->
 # we want to be able to get the results for year 2000, 2001, ... and 2050. Hence, we need to run
-# more time steps after 2050
+# more time steps after 2050, in particular up to 2051-1/12
 
-# # On develop branch: Creates 611 entries -> if taken the integer,the last year doesn't have enough entries
-# On temporal weights: Creates 612 entries -> but 13 in 2038 and 11 in 2048
+# Currently, at.ProjectSettings.tvec creates 611 entries -> if taken the integer,the last year doesn't have enough entries
 
 import atomica as at
 import numpy as np
+import pandas as pd
 
 
 def test_time_vector():
+    # Test 1
     # Creating a setting object
     analysis_years = (2000, 2050)
     dt = 1 / 12
     settings = at.ProjectSettings(sim_start=analysis_years[0], sim_end=analysis_years[1] + 1 - dt, sim_dt=dt)  #: Atomica project settings
     tvec = settings.tvec  #: Simulation/result time points
-
-    assert len(set(np.unique(tvec.astype(int), return_counts=True)[1])) == 1
-    
-    # on temporal weights branch: np.linspace(self.sim_start, self.sim_end, int(np.float32(((self.sim_end - self.sim_start) / self.sim_dt))) + 1)
-    #  tvec = np.linspace(2000, 2051-1/12, int(np.float32(((2051-1/12 - 2000) / (1/12)))) + 1)
-
-    # on develop branch: np.linspace(self.sim_start, self.sim_end, int((self.sim_end - self.sim_start) / self.sim_dt) + 1)
-    # develop: tvec = np.linspace(2000, 2051-1/12, int((2051-1/12 - 2000) / (1/12)) + 1)
-    # np.unique(tvec.astype(int), return_counts=True)
-
+    assert len(set(np.unique(tvec.astype(int), return_counts=True)[1])) == 1  # or pd.Series(tvec).astype(int).value_counts()
 
 
 if __name__ == "__main__":

--- a/tests/test_time_vector.py
+++ b/tests/test_time_vector.py
@@ -18,7 +18,7 @@ def test_time_vector():
     dt = 1 / 12
     settings = at.ProjectSettings(sim_start=analysis_years[0], sim_end=analysis_years[1] + 1 - dt, sim_dt=dt)  #: Atomica project settings
     tvec = settings.tvec  #: Simulation/result time points
-    assert len(set(np.unique(tvec.astype(int), return_counts=True)[1])) == 1  # or pd.Series(tvec).astype(int).value_counts()
+    assert set(np.unique(tvec.astype(int), return_counts=True)[1]) == {1/dt}  # or pd.Series(tvec).astype(int).value_counts()
 
 
 if __name__ == "__main__":


### PR DESCRIPTION
Fix simulation time vector:
Problem: When using `np.linspace(2000, 2051-1/12, int(np.float32(((2051-1/12 - 2000) / (1/12)))) + 1))` to generate the time vector, we can convert it to an integer array and return the counts for each year, and we will end up with 12 counts for most years, but 13 counts for year 2038 and 11 counts for 2048 due to numerical imprecision of the step size calculated by `np.linspace`. And this is causing issues in the results. 

This PR is using a different approach (credits to Kelvin!): 
1. Use `arange` with step size of 1 which is exact
2. Use our correct step size and multiply it
3. Add our start time