### PR TITLE
Progset fix for targeting junctions

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,8 +4,18 @@ This file records changes to the codebase grouped by version release. Unreleased
 
 ## [1.31.7] - 2026-05-29
 
+- Prevent running the model without a coverage overwrite for `ProgramSet` instances that require them. Previously a warning was intended to have been displayed, but a separate bug prevented this warning from being displayed
 - If a program targets source/sink compartments, the coverage will now be computed based on flows
 - When loading data into a project, only change the simulation start year if the databook contains time points
+
+*Backwards-compatibility notes*
+
+- Models that previously targeted junctions and were being run without a coverage overwrite will now raise a `ModelError` upon execution, whereas previously they would run but produce invalid results
+
+## [1.31.6] - 2026-05-27
+
+- Update `ProjectData` so that variable codenames are written to the databook as named cells for each table in the databook
+
 ## [1.31.6] - 2026-05-27
 
 - Update `ProjectData` so that variable codenames are written to the databook as named cells for each table in the databook

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,9 @@
 
 This file records changes to the codebase grouped by version release. Unreleased changes are generally only present during development (relevant parts of the changelog can be written and saved in that section before a version number has been assigned)
 
+## [1.31.7] - 2026-05-29
+
+- When loading data into a project, only change the simulation start year if the databook contains time points
 ## [1.31.6] - 2026-05-27
 
 - Update `ProjectData` so that variable codenames are written to the databook as named cells for each table in the databook

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,7 @@ This file records changes to the codebase grouped by version release. Unreleased
 
 ## [1.31.7] - 2026-05-29
 
+- If a program targets source/sink compartments, the coverage will now be computed based on flows
 - When loading data into a project, only change the simulation start year if the databook contains time points
 ## [1.31.6] - 2026-05-27
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -26,7 +26,7 @@ This file records changes to the codebase grouped by version release. Unreleased
 - Added a separate numerical tolerance used for initialization (`at.model.model_settings['initialization_tolerance']`) which permits more approximate initializations while still maintaining the same numerical tolerance for the rest of the integration.
 - Added another logging level (`at.VERBOSE`) which enables more targeted additional output
 
-- *Backwards-compatibility notes*
+*Backwards-compatibility notes*
 
 - Some initializations might show numerical (e.g., `1e-10`) differences in their values due to the new algorithm. In a small number of cases (depending on the framework), it is possible that the updated initialization method could result in a slightly different initialization.  
 - The default initialization tolerance is now `1e-3` instead of `1e-6`, some models that previously raised a `BadInitialization` error will now run without error. Users should note that if it's necessary to guarantee an exact initialization, this tolerance should be reduced. 

--- a/atomica/data.py
+++ b/atomica/data.py
@@ -93,7 +93,7 @@ class ProjectData(sc.prettyobj):
         have different time values). This quantity should be used when changing the simulation
         start year, if using all of the data in the databook is desired.
 
-        :return: The earliest year in the databook
+        :return: The earliest year in the databook, or ``None`` if no time points are present
 
         """
 
@@ -101,7 +101,11 @@ class ProjectData(sc.prettyobj):
         for table in self.tables():
             if len(table.tvec) and np.amin(table.tvec) < start_year:
                 start_year = np.amin(table.tvec)
-        return start_year
+
+        if np.isfinite(start_year):
+            return start_year
+        else:
+            return None
 
     @property
     def end_year(self) -> float:
@@ -121,7 +125,11 @@ class ProjectData(sc.prettyobj):
         for table in self.tables():
             if len(table.tvec) and np.amax(table.tvec) > end_year:
                 end_year = np.amax(table.tvec)
-        return end_year
+
+        if np.isfinite(end_year):
+            return end_year
+        else:
+            return None
 
     def change_tvec(self, tvec: np.array) -> None:
         """

--- a/atomica/excel.py
+++ b/atomica/excel.py
@@ -8,6 +8,7 @@ For example, Excel formatting, and time-varying data entry tables, are implement
 
 """
 
+import re
 from xlsxwriter.utility import xl_rowcol_to_cell as xlrc
 import sciris as sc
 import io
@@ -1077,7 +1078,9 @@ class TimeDependentValuesEntry:
             worksheet.write(current_row, i, entry, formats["center_bold"])
             update_widths(widths, i, entry)
 
-        if self.code_name is not None and workbook is not None:
+        if self.code_name is not None and workbook is not None and not re.match(r"^[a-zA-Z][a-zA-Z]?[a-dA-D]?\d+$", self.code_name):
+            # Define an Excel named cell with the code name of the quantity in the table. However, this is only allowed in Excel if the code_name is
+            # not a valid cell reference e.g., 'A1' so we need to check for this first.
             workbook.define_name(self.code_name, "='%s'!%s" % (worksheet.name, xlrc(current_row, 0, True, True)))
 
         if not pd.isna(self.comment):

--- a/atomica/migration.py
+++ b/atomica/migration.py
@@ -861,3 +861,11 @@ def _projectdata_add_tdve_codename(D):
         if not hasattr(tdve, "code_name"):
             tdve.code_name = None
     return D
+
+
+@migration("ProgramSet", "1.31.6", "1.31.7", "Ensure non-targetable flag is present")
+def _progset_nontargetable_flag(progset):
+    for d in progset.comps.values():
+        if 'non_targetable' not in d:
+            d['non_targetable'] = False
+    return progset

--- a/atomica/model.py
+++ b/atomica/model.py
@@ -2117,10 +2117,12 @@ class Model:
             # Check that any programs with no coverage denominator have been given coverage overwrites
             # Otherwise, the coverage denominator will be treated as 0 and will result in 100% coverage
             # but that would just be a side effect of not targeting anyone (division by 0 is treated as 100%)
+            non_targetable = {comp for comp, spec in self.progset.comps.items() if spec['non_targetable']}
             for prog in self.progset.programs.values():
                 if not self._program_cache["comps"][prog.name] and prog.name not in self._program_cache["prop_coverage"]:
                     raise ModelError(f'Program "{prog.name}" does not target any compartments, but the program instructions did not specify coverage for this program. Programs without target compartments require their coverage to be explicitly specified in the instructions')
-
+                if non_targetable and not non_targetable.isdisjoint(prog.target_comps) and prog.name not in self._program_cache["prop_coverage"]:
+                    raise ModelError(f'Program "{prog.name}" targets special compartments {non_targetable.intersection(prog.target_comps)}, but the program instructions did not specify coverage for this program. Programs that target special compartments (junctions/sources/sinks) require their coverage to be explicitly specified in the instructions')
         else:
             self.programs_active = False
 

--- a/atomica/programs.py
+++ b/atomica/programs.py
@@ -326,7 +326,7 @@ class ProgramSet(NamedItem):
 
         del self.pops[code_name]
 
-    def add_comp(self, code_name: str, full_name: str, pop_type: str = None) -> None:
+    def add_comp(self, code_name: str, full_name: str, pop_type: str = None, non_targetable: bool = False) -> None:
         """
         Add a compartment
 
@@ -335,12 +335,11 @@ class ProgramSet(NamedItem):
 
         :param code_name: Code name of the compartment to add
         :param full_name: Full name of the compartment to add
-
+        :param non_targetable: Flag whether the compartment is targetable, or a special non-targetable compartment like a junction
         """
         if pop_type is None:
             pop_type = self._pop_types[0]
-
-        self.comps[code_name] = {"label": full_name, "type": pop_type}
+        self.comps[code_name] = {"label": full_name, "type": pop_type, "non_targetable": non_targetable}
 
     def remove_comp(self, name: str) -> None:
         """
@@ -557,8 +556,7 @@ class ProgramSet(NamedItem):
         ss.save(fname)
 
     def _read_targeting(self, sheet, framework) -> None:
-        # This function reads a targeting sheet and instantiates all of the programs with appropriate targets, putting them
-        # into `self.programs`
+        # This function reads a targeting sheet and instantiates all of the programs with appropriate targets, putting them into `self.programs`
         tables, start_rows = read_tables(sheet)  # NB. only the first table will be read, so there can be other tables for comments on the first page
         self.programs = sc.odict()
         sup_header = [x.value.lower().strip() if sc.isstring(x.value) else x.value for x in tables[0][0]]
@@ -596,24 +594,15 @@ class ProgramSet(NamedItem):
                         message = "There was a mismatch between the populations in the databook and the populations in the program book"
                         message += '\nThe program book contains population "%s", while the databook contains: %s' % (pop_idx[i], [str(x) for x in pop_codenames.keys()])
                         raise Exception(message)
-
                     target_pops.append(pop_codenames[pop_idx[i]])  # Append the pop's codename
 
             for i in range(comp_start_idx, len(headers)):
                 if row[i].value and sc.isstring(row[i].value) and row[i].value.lower().strip() == "y":
                     if comp_idx[i] not in comp_codenames:
-                        if comp_idx[i] in set(framework.comps["display name"].str.lower().str.strip()):
-                            # It's a valid compartment of some sort (not actually targetable - for use with coverage scenarios only)
-                            logger.warning(f'Compartment "{comp_idx[i]}" is a non-standard compartment that cannot be targeted. The ProgramSet can be used with coverage scenarios only')
-                            spec = framework.comps.loc[framework.comps["display name"].str.lower().str.strip() == comp_idx[i]]
-                            self.add_comp(code_name=spec.index[0], full_name=spec["display name"][0], pop_type=spec["population type"][0])
-                            target_comps.append(spec.index[0])  # Append the pop's codename
-                        else:
-                            message = "There was a mismatch between the compartments in the databook and the compartments in the Framework file"
-                            message += '\nThe program book contains compartment "%s", while the Framework contains: %s' % (comp_idx[i], [str(x) for x in comp_codenames.keys()])
-                            raise Exception(message)
-                    else:
-                        target_comps.append(comp_codenames[comp_idx[i]])  # Append the pop's codename
+                        message = "There was a mismatch between the compartments in the databook and the compartments in the Framework file"
+                        message += '\nThe program book contains compartment "%s", while the Framework contains: %s' % (comp_idx[i], [str(x) for x in comp_codenames.keys()])
+                        raise Exception(message)
+                    target_comps.append(comp_codenames[comp_idx[i]])  # Append the pop's codename
 
             short_name = row[0].value.strip()
             if short_name.lower() == "all":

--- a/atomica/results.py
+++ b/atomica/results.py
@@ -240,7 +240,7 @@ class Result(NamedItem):
 
         """
 
-        from .model import JunctionCompartment
+        from .model import JunctionCompartment, SourceCompartment, SinkCompartment
 
         if self.model.progset is None:
             return None
@@ -259,8 +259,10 @@ class Result(NamedItem):
                     for comp_name in prog.target_comps:
                         comp = self.get_variable(comp_name, pop_name)[0]
 
-                        if isinstance(comp, JunctionCompartment):
+                        if isinstance(comp, JunctionCompartment) or isinstance(comp, SourceCompartment):
                             vals = comp.outflow
+                        elif isinstance(comp, SinkCompartment):
+                            vals = comp.inflow
                         else:
                             vals = comp.vals
 

--- a/atomica/version.py
+++ b/atomica/version.py
@@ -3,5 +3,5 @@ Atomica version file.
 
 Standard location for module version number and date.
 """
-version = "1.31.6"
+version = "1.31.7"
 versiondate = "2026-05-27"

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -54,3 +54,13 @@ where = ["."]
 
 [tool.setuptools.dynamic]
 version = {attr = "atomica.version.version"}
+
+[dependency-groups]
+local = [
+    "ipython",
+    "pandas-stubs",
+    "scipy-stubs",
+]
+
+[tool.uv]
+default-groups = ["local"]

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -60,6 +60,8 @@ local = [
     "ipython",
     "pandas-stubs",
     "scipy-stubs",
+    "pytest-xdist",
+    "pytest-cov",
 ]
 
 [tool.uv]


### PR DESCRIPTION
Targeting junctions was previously supposed to display a warning that in such cases, the programs must be run with coverage overwrites in the instructions. However, there was an error in how this was checked, with the result that no warning was displayed and the programs would run with 100% coverage, even though the program output in results would report the 'correct' coverage for the given level of spending.

This update formally checks for the coverage overwrite and prevents running the model if a coverage overwrite is required but not provided