### PR TITLE
Update MCP package version

### DIFF
--- a/atomica/mcp/server.py
+++ b/atomica/mcp/server.py
@@ -1,13 +1,13 @@
 from typing import Annotated
 import pandas as pd
 from pydantic import Field
-from mcp.server.fastmcp import FastMCP
+from mcp.server import MCPServer
 from mcp.types import ToolAnnotations
 import atomica as at
 from atomica.function_parser import parse_function
 from atomica.mcp.skills import register_skills
 
-mcp = FastMCP(
+mcp = MCPServer(
     "atomica",
     instructions=(
         "Tools for querying Atomica framework .xlsx files. "

--- a/atomica/mcp/skills/__init__.py
+++ b/atomica/mcp/skills/__init__.py
@@ -2,7 +2,7 @@ from pathlib import Path
 
 
 def register_skills(mcp) -> None:
-    """Scan *.md files in this directory and register each as a FastMCP prompt.
+    """Scan *.md files in this directory and register each as an MCP prompt.
 
     Each .md file should be structured as:
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -39,7 +39,7 @@ dependencies = [
     "hyperopt",
     "sciris",
     "tqdm",
-    "mcp",
+    "mcp>=2.0",
 ]
 
 [project.optional-dependencies]


### PR DESCRIPTION
`mcp` 2.0.0 introduced a breaking change by renaming `FastMCP` to `MCPServer`. This fixes it and upward-pins the version in `pyproject.toml`.

See https://py.sdk.modelcontextprotocol.io/whats-new/